### PR TITLE
BUG: replace reserved keyword `freq` with `cadence`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Update sat_id to inst_id for pysat 3.0 compatibility
 - migrate pyglow interface to pysatIncubator
 - Style updates for consistency with pysat 3.0
+  - Use `cadence` instead of `freq`
 - Migrate CI testing to Github Actions
 
 ## [0.2.1] - 2020-07-29

--- a/pysatMissions/instruments/pysat_ephem.py
+++ b/pysatMissions/instruments/pysat_ephem.py
@@ -85,7 +85,7 @@ clean = mcore._clean
 
 
 def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
-         TLE1=None, TLE2=None, num_samples=None, freq='1S'):
+         TLE1=None, TLE2=None, num_samples=None, cadence='1S'):
     """
     Returns data and metadata in the format required by pysat. Generates
     position of satellite in both geographic and ECEF co-ordinates.
@@ -117,7 +117,7 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
         Second string for Two Line Element. Must be in TLE format (default=None)
     num_samples : int or NoneType
         Number of samples per day (default=None)
-    freq : str
+    cadence : str
         Uses pandas.frequency string formatting ('1S', etc)
         (default='1S')
 
@@ -157,7 +157,8 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
         num_samples = 100
 
     # Extract list of times from filenames and inst_id
-    times, index, dates = ps_meth.generate_times(fnames, num_samples, freq=freq)
+    times, index, dates = ps_meth.generate_times(fnames, num_samples,
+                                                 freq=cadence)
 
     # the observer's (ground station) position on the Earth surface
     site = ephem.Observer()

--- a/pysatMissions/instruments/pysat_sgp4.py
+++ b/pysatMissions/instruments/pysat_sgp4.py
@@ -62,7 +62,7 @@ clean = mcore._clean
 
 
 def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
-         TLE1=None, TLE2=None, num_samples=None, freq='1S'):
+         TLE1=None, TLE2=None, num_samples=None, cadence='1S'):
     """
     Returns data and metadata in the format required by pysat. Generates
     position of satellite in ECI co-ordinates.
@@ -94,7 +94,7 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
         Second string for Two Line Element. Must be in TLE format
     num_samples : int
         Number of samples per day
-    freq : str
+    cadence : str
         Uses pandas.frequency string formatting ('1S', etc)
         (default='1S')
 
@@ -141,7 +141,8 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
     satellite = twoline2rv(line1, line2, wgs72)
 
     # Extract list of times from filenames and inst_id
-    times, index, dates = ps_meth.generate_times(fnames, num_samples, freq=freq)
+    times, index, dates = ps_meth.generate_times(fnames, num_samples,
+                                                 freq=cadence)
 
     # create list to hold satellite position, velocity
     position = []

--- a/pysatMissions/tests/test_instruments.py
+++ b/pysatMissions/tests/test_instruments.py
@@ -1,3 +1,5 @@
+import datetime as dt
+import numpy as np
 import tempfile
 
 import pytest
@@ -66,3 +68,21 @@ class TestInstruments(InstTestClass):
         pysat.params.data['data_dirs'] = self.saved_path
         self.tempdir.cleanup()
         del self.inst_loc, self.saved_path, self.tempdir
+
+    # Custom package unit tests can be added here
+
+    @pytest.mark.parametrize("inst_dict", [x for x in instruments['download']])
+    @pytest.mark.parametrize("kwarg,output", [(None, 1), ('10s', 10)])
+    def test_inst_cadence(self, inst_dict, kwarg, output):
+        """Test operation of cadence keyword, including default behavior"""
+
+        if kwarg:
+            self.test_inst = pysat.Instrument(
+                inst_module=inst_dict['inst_module'], cadence=kwarg)
+        else:
+            self.test_inst = pysat.Instrument(
+                inst_module=inst_dict['inst_module'])
+
+        self.test_inst.load(2019, 1)
+        cadence = np.diff(self.test_inst.data.index.to_pydatetime())
+        assert np.all(cadence == dt.timedelta(seconds=output))


### PR DESCRIPTION
# Description

Addresses #50 

With the release of pysat 3.0.0, `freq` is now a reserved keyword.  Changing to `cadence` for the purposes of this package.  This is more descriptive, as the string is the desired measurement cadence.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Import a module with a different cadence than the default ('1s') using the `cadence` keyword`.  
2. Load the data
3. Check that data is at desired cadence

Example:
```
import pysat
import pysatMissions
test = pysat.Instrument(inst_module=pysatMissions.instruments.pysat_ephem, cadence='10s')
test.load(2019, 1)
```
Note that instrument registration is broken due to #49.  This will be fixed in a separate pull.

**Test Configuration**:
* Mac OS X 10.15.7
* python 3.8.2

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
