### PR TITLE
ENH: Update usage of sgp4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.3.0] - 2021-06-24
 * Add Keplerian orbital inputs into missions_sgp4
 * Update sgp4 interface to use new syntax for initialization from TLEs
+* Improve metadata generation in missions_sgp4
 
 ## [0.2.2] - 2021-06-18
 * Migrate pyglow interface to pysatIncubator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.3.0] - 2021-06-24
 * Add Keplerian orbital inputs into missions_sgp4
+* Update sgp4 interface to use new syntax for initialization from TLEs
 
 ## [0.2.2] - 2021-06-18
 * Migrate pyglow interface to pysatIncubator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.0] - 2021-06-24
+* Add Keplerian orbital inputs into missions_sgp4
+
 ## [0.2.2] - 2021-06-18
 * Migrate pyglow interface to pysatIncubator
 * Style updates for consistency with pysat 3.0

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Python 3.7+.
 | numpy          | aacgmv2           |
 | pandas         | apexpy            |
 | pyEphem        | OMMBV             |
-| sgp4           | pysat>=3.0        |
+| sgp4>=2.7      | pysat>=3.0        |
 
 
 One way to install is through pip.  Just type

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,7 +23,7 @@ Python 3.7+ and pysat 3.0.0+.
   numpy            aacgmv2
   pandas           apexpy
   pyEphem          OMMBV
-  sgp4             pysat>=3.0
+  sgp4>=2.7        pysat>=3.0
  ================ ==================
 
 

--- a/pysatMissions/__init__.py
+++ b/pysatMissions/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 import logging
 import os
 

--- a/pysatMissions/instruments/__init__.py
+++ b/pysatMissions/instruments/__init__.py
@@ -3,6 +3,7 @@ pysatMissions.instruments is a pysat module that provides
 the instrument modules to be used with pysat
 """
 
+from pysatMissions.instruments import methods  # noqa: F401
 from pysatMissions.instruments import missions_ephem, missions_sgp4
 
 __all__ = ['missions_ephem', 'missions_sgp4']

--- a/pysatMissions/instruments/methods/__init__.py
+++ b/pysatMissions/instruments/methods/__init__.py
@@ -1,0 +1,3 @@
+from pysatMissions.instruments.methods import orbits
+
+__all__ = ['orbits']

--- a/pysatMissions/instruments/methods/__init__.py
+++ b/pysatMissions/instruments/methods/__init__.py
@@ -1,3 +1,5 @@
+"""Methods to support multiple instrument files."""
+
 from pysatMissions.instruments.methods import orbits
 
 __all__ = ['orbits']

--- a/pysatMissions/instruments/methods/orbits.py
+++ b/pysatMissions/instruments/methods/orbits.py
@@ -1,0 +1,84 @@
+import numpy as np
+
+
+def convert_to_keplerian(alt_periapsis, alt_apoapsis=None, planet='Earth'):
+    """Calculate orbital eccentricity from periapsis and apoapsis
+
+    Parameters
+    ----------
+    alt_periapsis : float
+        The lowest altitude from the mean planet surface along the orbit (km)
+    alt_apoapsis : float or NoneType
+        The highest altitude from the mean planet surface along the orbit (km)
+        If None, assumed to be equal to periapsis. (default=None)
+    planet : string
+        The name of the planet of interest.  Used for radial calculations.
+        (default='Earth')
+
+    Returns
+    -------
+    eccentricity : float
+        The eccentricty of the orbit (unitless)
+    mean_motion : float
+        The mean angular speed of the orbit (rad/minute)
+
+    """
+
+    radius = {'Earth': 6371}  # km
+    mass = {'Earth': 5.9742e24}  # kg
+    gravity = 6.6743e-11  # m**3 kg / s**2
+
+    if alt_apoapsis is None:
+        alt_apoapsis = alt_periapsis
+
+    rad_apoapsis = alt_apoapsis + radius[planet]
+    rad_periapsis = alt_periapsis + radius[planet]
+    semimajor = 0.5 * (rad_apoapsis + rad_periapsis)
+
+    eccentricity = ((rad_apoapsis - rad_periapsis)
+                    / (rad_apoapsis + rad_periapsis))
+
+    # convert axis to m, mean_motion to rad / minute
+    mean_motion = np.sqrt(gravity * mass[planet] / (1000 * semimajor)**3) * 60
+
+    return eccentricity, mean_motion
+
+
+def convert_from_keplerian(eccentricity, mean_motion, planet='Earth'):
+    """Calculate orbital eccentricity from periapsis and apoapsis
+
+    Parameters
+    ----------
+    eccentricity : float
+        The eccentricty of the orbit (unitless)
+    mean_motion : float
+        The mean angular speed of the orbit (rad/minute)
+    planet : string
+        The name of the planet of interest.  Used for radial calculations.
+        (default='Earth')
+
+    Returns
+    -------
+    alt_periapsis : float
+        The lowest altitude from the mean planet surface along the orbit (km)
+    alt_apoapsis : float
+        The highest altitude from the mean planet surface along the orbit (km)
+
+    """
+
+    radius = {'Earth': 6371}  # km
+    mass = {'Earth': 5.9742e24}  # kg
+    gravity = 6.6743e-11  # m**3 kg / s**2
+
+    # Convert mean_motion to rad / second before computing
+    semimajor = (gravity * mass[planet] / (mean_motion / 60)**2)
+    # Convert distance to km
+    semimajor = semimajor**(1 / 3) / 1000
+
+    rad_apoapsis = semimajor * (1 + eccentricity)
+    rad_periapsis = semimajor * (1 - eccentricity)
+
+    alt_apoapsis = rad_apoapsis - radius[planet]
+    alt_periapsis = rad_periapsis - radius[planet]
+
+    return alt_periapsis, alt_apoapsis

--- a/pysatMissions/instruments/methods/orbits.py
+++ b/pysatMissions/instruments/methods/orbits.py
@@ -35,7 +35,7 @@ def _get_constants(planet='Earth'):
 
     Parameters
     ----------
-    planet : string
+    planet : str
         The name of the planet of interest.
         (default='Earth')
 
@@ -69,7 +69,7 @@ def convert_to_keplerian(alt_periapsis, alt_apoapsis=None, planet='Earth'):
     alt_apoapsis : float or NoneType
         The highest altitude from the mean planet surface along the orbit (km)
         If None, assumed to be equal to periapsis. (default=None)
-    planet : string
+    planet : str
         The name of the planet of interest.  Used for radial calculations and
         mass.
         (default='Earth')

--- a/pysatMissions/instruments/methods/orbits.py
+++ b/pysatMissions/instruments/methods/orbits.py
@@ -1,3 +1,5 @@
+"""Methods to convert orbital information for propagators."""
+
 import numpy as np
 import warnings
 
@@ -15,8 +17,7 @@ def _check_orbital_params(kwargs=None):
 
     elements = list(kwargs['load'].keys())
 
-    keplerians = ['alt_periapsis', 'alt_apoapsis', 'inclination', 'bstar',
-                  'arg_periapsis', 'raan', 'mean_anomaly']
+    keplerians = ['alt_periapsis', 'inclination']
     tles = ['TLE1', 'TLE2']
     errmsg = 'Insufficient kwargs.  Kwarg group requires {:}'
     for group in [tles, keplerians]:
@@ -44,12 +45,12 @@ def _get_constants(planet='Earth'):
     radius : float (km)
         The average radius to the surface of a planet.
     mass : float (kg)
-        The avergae mass of the planet.
+        The average mass of the planet.
     gravity : float (m**3 kg / s**2)
         Newton's gravitational constant
     """
 
-    radius = {'Earth': 6371}
+    radius = {'Earth': 6371.2}
     mass = {'Earth': 5.9742e24}
     gravity = 6.6743e-11
 

--- a/pysatMissions/instruments/methods/orbits.py
+++ b/pysatMissions/instruments/methods/orbits.py
@@ -3,15 +3,44 @@ import numpy as np
 
 def check_orbital_params(inclination=None, eccentricity=None, raan=None,
                          arg_perigee=None, mean_anomaly=None, mean_motion=None):
-    """Check that a complete set of orbital parameters exist"""
+    """Check that a complete set of orbital parameters exist."""
 
     params = [inclination, eccentricity, raan, arg_perigee, mean_anomaly,
               mean_motion]
     return not any(v is None for v in params)
 
 
+def _get_params(planet='Earth'):
+    """Retrieve planetary constants for calculations.
+
+    Parameters
+    ----------
+    planet : string
+        The name of the planet of interest.
+        (default='Earth')
+
+    Returns
+    -------
+    radius : float (km)
+        The average radius to the surface of a planet.
+    mass : float (kg)
+        The avergae mass of the planet.
+    gravity : float (m**3 kg / s**2)
+        Newton's gravitational constant
+    """
+
+    radius = {'Earth': 6371}
+    mass = {'Earth': 5.9742e24}
+    gravity = 6.6743e-11
+
+    if planet not in radius.keys():
+        raise KeyError('{:} is not yet a supported planet!'.format(planet))
+
+    return radius[planet], mass[planet], gravity
+
+
 def convert_to_keplerian(alt_periapsis, alt_apoapsis=None, planet='Earth'):
-    """Calculate orbital eccentricity from periapsis and apoapsis
+    """Calculate orbital eccentricity from periapsis and apoapsis.
 
     Parameters
     ----------
@@ -21,7 +50,8 @@ def convert_to_keplerian(alt_periapsis, alt_apoapsis=None, planet='Earth'):
         The highest altitude from the mean planet surface along the orbit (km)
         If None, assumed to be equal to periapsis. (default=None)
     planet : string
-        The name of the planet of interest.  Used for radial calculations.
+        The name of the planet of interest.  Used for radial calculations and
+        mass.
         (default='Earth')
 
     Returns
@@ -33,28 +63,25 @@ def convert_to_keplerian(alt_periapsis, alt_apoapsis=None, planet='Earth'):
 
     """
 
-    radius = {'Earth': 6371}  # km
-    mass = {'Earth': 5.9742e24}  # kg
-    gravity = 6.6743e-11  # m**3 kg / s**2
-
+    radius, mass, gravity = _get_params(planet)
     if alt_apoapsis is None:
         alt_apoapsis = alt_periapsis
 
-    rad_apoapsis = alt_apoapsis + radius[planet]
-    rad_periapsis = alt_periapsis + radius[planet]
+    rad_apoapsis = alt_apoapsis + radius
+    rad_periapsis = alt_periapsis + radius
     semimajor = 0.5 * (rad_apoapsis + rad_periapsis)
 
     eccentricity = ((rad_apoapsis - rad_periapsis)
                     / (rad_apoapsis + rad_periapsis))
 
     # convert axis to m, mean_motion to rad / minute
-    mean_motion = np.sqrt(gravity * mass[planet] / (1000 * semimajor)**3) * 60
+    mean_motion = np.sqrt(gravity * mass / (1000 * semimajor)**3) * 60
 
     return eccentricity, mean_motion
 
 
 def convert_from_keplerian(eccentricity, mean_motion, planet='Earth'):
-    """Calculate orbital eccentricity from periapsis and apoapsis
+    """Calculate orbital eccentricity from periapsis and apoapsis.
 
     Parameters
     ----------
@@ -75,19 +102,16 @@ def convert_from_keplerian(eccentricity, mean_motion, planet='Earth'):
 
     """
 
-    radius = {'Earth': 6371}  # km
-    mass = {'Earth': 5.9742e24}  # kg
-    gravity = 6.6743e-11  # m**3 kg / s**2
-
+    radius, mass, gravity = _get_params(planet)
     # Convert mean_motion to rad / second before computing
-    semimajor = (gravity * mass[planet] / (mean_motion / 60)**2)
+    semimajor = (gravity * mass / (mean_motion / 60)**2)
     # Convert distance to km
     semimajor = semimajor**(1 / 3) / 1000
 
     rad_apoapsis = semimajor * (1 + eccentricity)
     rad_periapsis = semimajor * (1 - eccentricity)
 
-    alt_apoapsis = rad_apoapsis - radius[planet]
-    alt_periapsis = rad_periapsis - radius[planet]
+    alt_apoapsis = rad_apoapsis - radius
+    alt_periapsis = rad_periapsis - radius
 
     return alt_periapsis, alt_apoapsis

--- a/pysatMissions/instruments/methods/orbits.py
+++ b/pysatMissions/instruments/methods/orbits.py
@@ -19,7 +19,8 @@ def _check_orbital_params(kwargs=None):
         warnings.warn(' '.join(['Cannot use both Keplerians and TLEs.',
                                 'Defaulting to Keplerians.']))
 
-def _get_params(planet='Earth'):
+
+def _get_constants(planet='Earth'):
     """Retrieve planetary constants for calculations.
 
     Parameters
@@ -72,7 +73,7 @@ def convert_to_keplerian(alt_periapsis, alt_apoapsis=None, planet='Earth'):
 
     """
 
-    radius, mass, gravity = _get_params(planet)
+    radius, mass, gravity = _get_constants(planet)
     if alt_apoapsis is None:
         alt_apoapsis = alt_periapsis
 
@@ -111,7 +112,7 @@ def convert_from_keplerian(eccentricity, mean_motion, planet='Earth'):
 
     """
 
-    radius, mass, gravity = _get_params(planet)
+    radius, mass, gravity = _get_constants(planet)
     # Convert mean_motion to rad / second before computing
     semimajor = (gravity * mass / (mean_motion / 60)**2)
     # Convert distance to km

--- a/pysatMissions/instruments/methods/orbits.py
+++ b/pysatMissions/instruments/methods/orbits.py
@@ -3,7 +3,15 @@ import warnings
 
 
 def _check_orbital_params(kwargs=None):
-    """Check that a complete set of unconflicted orbital parameters exist."""
+    """Check that a complete set of unconflicted orbital parameters exist.
+
+    Parameters
+    ----------
+    kwargs : dict
+        Dictionary of optional kwargs passed through upon initialization
+        of pysat instrument.
+
+    """
 
     elements = list(kwargs['load'].keys())
 
@@ -18,6 +26,8 @@ def _check_orbital_params(kwargs=None):
     if all(v in elements for v in tles) and all(v in elements for v in keplerians):
         warnings.warn(' '.join(['Cannot use both Keplerians and TLEs.',
                                 'Defaulting to Keplerians.']))
+
+    return
 
 
 def _get_constants(planet='Earth'):

--- a/pysatMissions/instruments/methods/orbits.py
+++ b/pysatMissions/instruments/methods/orbits.py
@@ -1,14 +1,23 @@
 import numpy as np
+import warnings
 
 
-def check_orbital_params(inclination=None, eccentricity=None, raan=None,
-                         arg_perigee=None, mean_anomaly=None, mean_motion=None):
-    """Check that a complete set of orbital parameters exist."""
+def _check_orbital_params(kwargs=None):
+    """Check that a complete set of unconflicted orbital parameters exist."""
 
-    params = [inclination, eccentricity, raan, arg_perigee, mean_anomaly,
-              mean_motion]
-    return not any(v is None for v in params)
+    elements = list(kwargs['load'].keys())
 
+    keplerians = ['alt_periapsis', 'alt_apoapsis', 'inclination', 'drag_coeff',
+                  'arg_periapsis', 'raan', 'mean_anomaly']
+    tles = ['TLE1', 'TLE2']
+    errmsg = 'Insufficient kwargs.  Kwarg group requires {:}'
+    for group in [tles, keplerians]:
+        if any(v in elements for v in group):
+            if not all(v in elements for v in group):
+                raise KeyError(errmsg.format(', '.join(group)))
+    if all(v in elements for v in tles) and all(v in elements for v in keplerians):
+        warnings.warn(' '.join(['Cannot use both Keplerians and TLEs.',
+                                'Defaulting to Keplerians.']))
 
 def _get_params(planet='Earth'):
     """Retrieve planetary constants for calculations.

--- a/pysatMissions/instruments/methods/orbits.py
+++ b/pysatMissions/instruments/methods/orbits.py
@@ -1,6 +1,15 @@
 import numpy as np
 
 
+def check_orbital_params(inclination=None, eccentricity=None, raan=None,
+                         arg_perigee=None, mean_anomaly=None, mean_motion=None):
+    """Check that a complete set of orbital parameters exist"""
+
+    params = [inclination, eccentricity, raan, arg_perigee, mean_anomaly,
+              mean_motion]
+    return not any(v is None for v in params)
+
+
 def convert_to_keplerian(alt_periapsis, alt_apoapsis=None, planet='Earth'):
     """Calculate orbital eccentricity from periapsis and apoapsis
 

--- a/pysatMissions/instruments/methods/orbits.py
+++ b/pysatMissions/instruments/methods/orbits.py
@@ -15,7 +15,7 @@ def _check_orbital_params(kwargs=None):
 
     elements = list(kwargs['load'].keys())
 
-    keplerians = ['alt_periapsis', 'alt_apoapsis', 'inclination', 'drag_coeff',
+    keplerians = ['alt_periapsis', 'alt_apoapsis', 'inclination', 'bstar',
                   'arg_periapsis', 'raan', 'mean_anomaly']
     tles = ['TLE1', 'TLE2']
     errmsg = 'Insufficient kwargs.  Kwarg group requires {:}'

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -99,12 +99,22 @@ def load(fnames, tag=None, inst_id=None,
     inclination : float
         Orbital Inclination in degrees (default=None)
     raan : float
-        Right Ascension of the Ascending Node in degrees (default=None)
+        Right Ascension of the Ascending Node (RAAN) in degrees. This defines
+        the orientation of the orbital plane to the generalized reference frame.
+        The Ascending Node is the point in the orbit where the spacecraft passes
+        through the plane of reference moving northward.  For Earth orbits, the
+        location of the RAAN is defined as the angle eastward of the First Point
+        of Aries.
+        (default=None)
     arg_periapsis : float
-        Argument of Periapsis in degrees (default=None)
+        Argument of Periapsis in degrees.  This defines the orientation of the
+        ellipse in the orbital plane, as an angle measured from the ascending
+        node to the periapsis  (default=None)
     mean_anomaly : float
         The fraction of an elliptical orbit's period that has elapsed since the
-        orbiting body passed periapsis
+        orbiting body passed periapsis.  Note that this is a "fictitious angle"
+        (input in degrees) which defines the location of the spacecraft in the
+        orbital plane based on the orbital period.
         (default=None)
     bstar : float
         Inverse of the ballistic coefficient. Used to model satellite drag.

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -167,7 +167,7 @@ def load(fnames, tag=None, inst_id=None,
                            mean_motion, np.radians(raan))
     else:
         # Otherwise, use TLEs
-        satellite = Satrec.twoline2rv(line1, line2)
+        satellite = Satrec.twoline2rv(line1, line2, whichconst=WGS72)
 
     jd = jd * np.ones(len(times))
     fr = times / 86400.

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -43,7 +43,7 @@ _test_dates = {'': {'': dt.datetime(2018, 1, 1)}}
 
 def init(self):
     """
-    Initializes the Instrument object with required values.
+    Initialize the Instrument object with required values.
 
     Runs once upon instantiation.
 

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -155,7 +155,7 @@ def load(fnames, tag=None, inst_id=None,
     epoch = (dates[0] - dt.datetime(1949, 12, 31)).days
     jd, _ = jday(dates[0].year, dates[0].month, dates[0].day, 0, 0, 0)
 
-    if inclination:
+    if inclination is not None:
         # If an inclination is provided, specify by Keplerian elements
         eccentricity, mean_motion = orbits.convert_to_keplerian(alt_periapsis,
                                                                 alt_apoapsis)

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -23,7 +23,7 @@ import pysat
 from pysat.instruments.methods import testing as ps_meth
 from pysatMissions.instruments import _core as mcore
 from pysatMissions.instruments.methods import orbits
-from sgp4.api import api as sapi
+from sgp4 import api as sapi
 
 logger = pysat.logger
 

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -66,13 +66,12 @@ def init(self):
 clean = mcore._clean
 
 
-def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
+def load(fnames, tag=None, inst_id=None,
          TLE1=None, TLE2=None, alt_periapsis=None, alt_apoapsis=None,
-         inclination=None, raan=None, arg_perigee=None, mean_anomaly=None,
+         inclination=None, raan=None, arg_periapsis=None, mean_anomaly=None,
          drag_coeff=None, num_samples=None, cadence='1S'):
     """
-    Returns data and metadata in the format required by pysat. Generates
-    position of satellite in ECI co-ordinates.
+    Generate position of satellite in ECI co-ordinates.
 
     Routine is directly called by pysat and not the user.
 
@@ -86,15 +85,6 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
         Instrument satellite ID (accepts '' or a number (i.e., '10'), which
         specifies the number of seconds to simulate the satellite)
         (default='')
-    obs_long: float
-        Longitude of the observer on the Earth's surface
-        (default=0.)
-    obs_lat: float
-        Latitude of the observer on the Earth's surface
-        (default=0.)
-    obs_alt: float
-        Altitude of the observer on the Earth's surface
-        (default=0.)
     TLE1 : string
         First string for Two Line Element. Must be in TLE format
     TLE2 : string
@@ -108,8 +98,8 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
         Orbital Inclination in degrees (default=None)
     raan : float
         Right Ascension of the Ascending Node in degrees (default=None)
-    arg_perigee : float
-        Argument of Perigee in degrees (default=None)
+    arg_periapsis : float
+        Argument of Periapsis in degrees (default=None)
     mean_anomaly : float
         The fraction of an elliptical orbit's period that has elapsed since the
         orbiting body passed periapsis
@@ -170,7 +160,7 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
         satellite = Satrec()
         # according to module webpage, wgs72 is common
         satellite.sgp4init(WGS72, 'i', 0, epoch, drag_coeff, 0, 0,
-                           eccentricity, np.radians(arg_perigee),
+                           eccentricity, np.radians(arg_periapsis),
                            np.radians(inclination), np.radians(mean_anomaly),
                            mean_motion, np.radians(raan))
     else:

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -18,11 +18,13 @@ inst_id
 
 import datetime as dt
 import functools
+import numpy as np
 import pandas as pds
 
 import pysat
 from pysat.instruments.methods import testing as ps_meth
 from pysatMissions.instruments import _core as mcore
+from pysatMissions.instruments.methods import orbits
 
 logger = pysat.logger
 
@@ -64,7 +66,9 @@ clean = mcore._clean
 
 
 def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
-         TLE1=None, TLE2=None, num_samples=None, cadence='1S'):
+         TLE1=None, TLE2=None, alt_periapsis=None, alt_apoapsis=None,
+         inclination=None, raan=None, arg_perigee=None, mean_anomaly=None,
+         drag_coeff=None, num_samples=None, cadence='1S'):
     """
     Returns data and metadata in the format required by pysat. Generates
     position of satellite in ECI co-ordinates.
@@ -94,6 +98,23 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
         First string for Two Line Element. Must be in TLE format
     TLE2 : string
         Second string for Two Line Element. Must be in TLE format
+    alt_periapsis : float
+        The lowest altitude from the mean planet surface along the orbit (km)
+    alt_apoapsis : float or NoneType
+        The highest altitude from the mean planet surface along the orbit (km)
+        If None, assumed to be equal to periapsis. (default=None)
+    inclination : float
+        Orbital Inclination in degrees (default=None)
+    raan : float
+        Right Ascension of the Ascending Node in degrees (default=None)
+    arg_perigee : float
+        Argument of Perigee in degrees (default=None)
+    mean_anomaly : float
+        The fraction of an elliptical orbit's period that has elapsed since the
+        orbiting body passed periapsis
+        (default=None)
+    drag_coeff : float
+        Drag coefficient (default=None)
     num_samples : int
         Number of samples per day
     cadence : str
@@ -121,13 +142,14 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
     # wgs72 is the most commonly used gravity model in satellite tracking
     # community
     from sgp4.earth_gravity import wgs72
+    from sgp4.api import jday, Satrec, SGP4_ERRORS, WGS72
     from sgp4.io import twoline2rv
 
     # TLEs (Two Line Elements for ISS)
     # format of TLEs is fixed and available from wikipedia...
     # lines encode list of orbital elements of an Earth-orbiting object
     # for a given point in time
-    line1 = ('1 25544U 98067A   18135.61844383  .00002728  00000-0  48567-4 0  9998')
+    line1 = ('1 25544U 98067A   18001.00000000  .00002728  00000-0  48567-4 0  9998')
     line2 = ('2 25544  51.6402 181.0633 0004018  88.8954  22.2246 15.54059185113452')
     # use ISS defaults if not provided by user
     if TLE1 is not None:
@@ -138,33 +160,65 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
     if num_samples is None:
         num_samples = 100
 
-    # Create satellite from TLEs and assuming a gravity model;
-    # according to module webpage, wgs72 is common
-    satellite = twoline2rv(line1, line2, wgs72)
-
     # Extract list of times from filenames and inst_id
     times, index, dates = ps_meth.generate_times(fnames, num_samples,
                                                  freq=cadence)
+    # Calculate epoch for orbital propagator
+    epoch = (dates[0] - dt.datetime(1949, 12, 31)).days
+    jd, _ = jday(dates[0].year, dates[0].month, dates[0].day, 0, 0, 0)
 
-    # Create list to hold satellite position, velocity
-    position = []
-    velocity = []
-    for timestep in index:
-        # orbit propagator - computes x,y,z position and velocity
-        pos, vel = satellite.propagate(timestep.year, timestep.month,
-                                       timestep.day, timestep.hour,
-                                       timestep.minute, timestep.second)
-        position.extend(pos)
-        velocity.extend(vel)
+    # Create satellite from TLEs and assuming a gravity model;
+    # according to module webpage, wgs72 is common
+    if inclination:
+        # If an inclination is provided, specify by Keplerian elements
+        eccentricity, mean_motion = orbits.convert_to_keplerian(alt_periapsis,
+                                                                alt_apoapsis)
+        satellite = Satrec()
+        satellite.sgp4init(WGS72, 'i', 0, epoch, drag_coeff, 0, 0,
+                           eccentricity, np.radians(arg_perigee),
+                           np.radians(inclination), np.radians(mean_anomaly),
+                           mean_motion, np.radians(raan))
+        jd = jd * np.ones(len(times))
+        fr = times / 86400.
 
-    # Put data into DataFrame
-    data = pds.DataFrame({'position_eci_x': position[::3],
-                          'position_eci_y': position[1::3],
-                          'position_eci_z': position[2::3],
-                          'velocity_eci_x': velocity[::3],
-                          'velocity_eci_y': velocity[1::3],
-                          'velocity_eci_z': velocity[2::3]},
-                         index=index)
+        err_code, position, velocity = satellite.sgp4_array(jd, fr)
+
+        # Check all propagated values for errors in propagation
+        for i in range(1, 7):
+            if np.any(err_code == i):
+                raise ValueError(SGP4_ERRORS[i])
+
+        # Put data into DataFrame
+        data = pds.DataFrame({'position_eci_x': position[:, 0],
+                              'position_eci_y': position[:, 1],
+                              'position_eci_z': position[:, 2],
+                              'velocity_eci_x': velocity[:, 0],
+                              'velocity_eci_y': velocity[:, 1],
+                              'velocity_eci_z': velocity[:, 2]},
+                             index=index)
+    else:
+        # Otherwise, use TLEs
+        satellite = twoline2rv(line1, line2, wgs72)
+
+        # Create list to hold satellite position, velocity
+        position = []
+        velocity = []
+        for timestep in index:
+            # orbit propagator - computes x,y,z position and velocity
+            pos, vel = satellite.propagate(timestep.year, timestep.month,
+                                           timestep.day, timestep.hour,
+                                           timestep.minute, timestep.second)
+            position.extend(pos)
+            velocity.extend(vel)
+
+        # Put data into DataFrame
+        data = pds.DataFrame({'position_eci_x': position[::3],
+                              'position_eci_y': position[1::3],
+                              'position_eci_z': position[2::3],
+                              'velocity_eci_x': velocity[::3],
+                              'velocity_eci_y': velocity[1::3],
+                              'velocity_eci_z': velocity[2::3]},
+                             index=index)
     data.index.name = 'Epoch'
 
     # TODO: add call for GEI/ECEF translation here => #56

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -71,7 +71,7 @@ clean = mcore._clean
 def load(fnames, tag=None, inst_id=None,
          TLE1=None, TLE2=None, alt_periapsis=None, alt_apoapsis=None,
          inclination=None, raan=None, arg_periapsis=None, mean_anomaly=None,
-         drag_coeff=None, num_samples=None, cadence='1S'):
+         bstar=None, num_samples=None, cadence='1S'):
     """
     Generate position of satellite in ECI co-ordinates.
 
@@ -106,8 +106,9 @@ def load(fnames, tag=None, inst_id=None,
         The fraction of an elliptical orbit's period that has elapsed since the
         orbiting body passed periapsis
         (default=None)
-    drag_coeff : float
-        Drag coefficient (default=None)
+    bstar : float
+        Inverse of the ballistic coefficient. Used to model satellite drag.
+        Measured in inverse distance (1 / earth radius). (default=None)
     num_samples : int
         Number of samples per day
     cadence : str
@@ -161,7 +162,7 @@ def load(fnames, tag=None, inst_id=None,
                                                                 alt_apoapsis)
         satellite = Satrec()
         # according to module webpage, wgs72 is common
-        satellite.sgp4init(WGS72, 'i', 0, epoch, drag_coeff, 0, 0,
+        satellite.sgp4init(WGS72, 'i', 0, epoch, bstar, 0, 0,
                            eccentricity, np.radians(arg_periapsis),
                            np.radians(inclination), np.radians(mean_anomaly),
                            mean_motion, np.radians(raan))

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -167,7 +167,7 @@ def load(fnames, tag=None, inst_id=None,
                            mean_motion, np.radians(raan))
     else:
         # Otherwise, use TLEs
-        satellite = Satrec.twoline2rv(line1, line2, whichconst=WGS72)
+        satellite = Satrec.twoline2rv(line1, line2, WGS72)
 
     jd = jd * np.ones(len(times))
     fr = times / 86400.

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -23,7 +23,7 @@ import pysat
 from pysat.instruments.methods import testing as ps_meth
 from pysatMissions.instruments import _core as mcore
 from pysatMissions.instruments.methods import orbits
-from sgp4.api import jday, Satrec, SGP4_ERRORS, WGS72
+from sgp4.api import api as sapi
 
 logger = pysat.logger
 
@@ -162,21 +162,21 @@ def load(fnames, tag=None, inst_id=None,
                                                  freq=cadence)
     # Calculate epoch for orbital propagator
     epoch = (dates[0] - dt.datetime(1949, 12, 31)).days
-    jd, _ = jday(dates[0].year, dates[0].month, dates[0].day, 0, 0, 0)
+    jd, _ = sapi.jday(dates[0].year, dates[0].month, dates[0].day, 0, 0, 0)
 
     if inclination is not None:
         # If an inclination is provided, specify by Keplerian elements
         eccentricity, mean_motion = orbits.convert_to_keplerian(alt_periapsis,
                                                                 alt_apoapsis)
-        satellite = Satrec()
+        satellite = sapi.Satrec()
         # according to module webpage, wgs72 is common
-        satellite.sgp4init(WGS72, 'i', 0, epoch, bstar, 0, 0,
+        satellite.sgp4init(sapi.WGS72, 'i', 0, epoch, bstar, 0, 0,
                            eccentricity, np.radians(arg_periapsis),
                            np.radians(inclination), np.radians(mean_anomaly),
                            mean_motion, np.radians(raan))
     else:
         # Otherwise, use TLEs
-        satellite = Satrec.twoline2rv(line1, line2, WGS72)
+        satellite = sapi.Satrec.twoline2rv(line1, line2, sapi.WGS72)
 
     jd = jd * np.ones(len(times))
     fr = times / 86400.
@@ -186,7 +186,7 @@ def load(fnames, tag=None, inst_id=None,
     # Check all propagated values for errors in propagation
     for i in range(1, 7):
         if np.any(err_code == i):
-            raise ValueError(SGP4_ERRORS[i])
+            raise ValueError(sapi.SGP4_ERRORS[i])
 
     # Put data into DataFrame
     data = pds.DataFrame({'position_eci_x': position[:, 0],

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -149,8 +149,8 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
     # format of TLEs is fixed and available from wikipedia...
     # lines encode list of orbital elements of an Earth-orbiting object
     # for a given point in time
-    line1 = ('1 25544U 98067A   18135.61844383  .00002728  00000-0  48567-4 0  9998')
-    line2 = ('2 25544  51.6402 181.0633 0004018  88.8954  22.2246 15.54059185113452')
+    line1 = '1 25544U 98067A   18135.61844383  .00002728  00000-0  48567-4 0  9998'
+    line2 = '2 25544  51.6402 181.0633 0004018  88.8954  22.2246 15.54059185113452'
     # use ISS defaults if not provided by user
     if TLE1 is not None:
         line1 = TLE1

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -149,7 +149,7 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
     # format of TLEs is fixed and available from wikipedia...
     # lines encode list of orbital elements of an Earth-orbiting object
     # for a given point in time
-    line1 = ('1 25544U 98067A   18001.00000000  .00002728  00000-0  48567-4 0  9998')
+    line1 = ('1 25544U 98067A   18135.61844383  .00002728  00000-0  48567-4 0  9998')
     line2 = ('2 25544  51.6402 181.0633 0004018  88.8954  22.2246 15.54059185113452')
     # use ISS defaults if not provided by user
     if TLE1 is not None:

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -187,44 +187,43 @@ def load(fnames, tag=None, inst_id=None,
                          index=index)
     data.index.name = 'Epoch'
 
+    # Create metadata corresponding to variables in load routine
+    meta = pysat.Meta()
+    meta['Epoch'] = {
+        meta.labels.units: 'Milliseconds since 1970-1-1',
+        meta.labels.notes: 'UTC time at middle of geophysical measurement.',
+        meta.labels.desc: 'UTC seconds',
+        meta.labels.name: 'Time index in milliseconds'}
+    meta['position_eci_x'] = {
+        meta.labels.units: 'km',
+        meta.labels.name: 'ECI x-position',
+        meta.labels.desc: 'Earth Centered Inertial x-position of satellite.'}
+    meta['position_eci_y'] = {
+        meta.labels.units: 'km',
+        meta.labels.name: 'ECI y-position',
+        meta.labels.desc: 'Earth Centered Inertial y-position of satellite.'}
+    meta['position_eci_z'] = {
+        meta.labels.units: 'km',
+        meta.labels.name: 'ECI z-position',
+        meta.labels.desc: 'Earth Centered Inertial z-position of satellite.'}
+    meta['velocity_eci_x'] = {
+        meta.labels.units: 'km/s',
+        meta.labels.desc: 'Satellite velocity along ECI-x',
+        meta.labels.name: 'Satellite velocity ECI-x'}
+    meta['velocity_eci_y'] = {
+        meta.labels.units: 'km/s',
+        meta.labels.desc: 'Satellite velocity along ECI-y',
+        meta.labels.name: 'Satellite velocity ECI-y'}
+    meta['velocity_eci_z'] = {
+        meta.labels.units: 'km/s',
+        meta.labels.desc: 'Satellite velocity along ECI-z',
+        meta.labels.name: 'Satellite velocity ECI-z'}
+
     # TODO: add call for GEI/ECEF translation here => #56
 
-    return data, meta.copy()
+    return data, meta
 
 
 list_files = functools.partial(ps_meth.list_files, test_dates=_test_dates)
 download = functools.partial(ps_meth.download)
 clean = functools.partial(mcore._clean)
-
-# Create metadata corresponding to variables in load routine just above
-# made once here rather than regenerate every load call
-meta = pysat.Meta()
-meta['Epoch'] = {
-    meta.labels.units: 'Milliseconds since 1970-1-1',
-    meta.labels.notes: 'UTC time at middle of geophysical measurement.',
-    meta.labels.desc: 'UTC seconds',
-    meta.labels.name: 'Time index in milliseconds'}
-meta['position_eci_x'] = {
-    meta.labels.units: 'km',
-    meta.labels.name: 'ECI x-position',
-    meta.labels.desc: 'Earth Centered Inertial x-position of satellite.'}
-meta['position_eci_y'] = {
-    meta.labels.units: 'km',
-    meta.labels.name: 'ECI y-position',
-    meta.labels.desc: 'Earth Centered Inertial y-position of satellite.'}
-meta['position_eci_z'] = {
-    meta.labels.units: 'km',
-    meta.labels.name: 'ECI z-position',
-    meta.labels.desc: 'Earth Centered Inertial z-position of satellite.'}
-meta['velocity_eci_x'] = {
-    meta.labels.units: 'km/s',
-    meta.labels.desc: 'Satellite velocity along ECI-x',
-    meta.labels.name: 'Satellite velocity ECI-x'}
-meta['velocity_eci_y'] = {
-    meta.labels.units: 'km/s',
-    meta.labels.desc: 'Satellite velocity along ECI-y',
-    meta.labels.name: 'Satellite velocity ECI-y'}
-meta['velocity_eci_z'] = {
-    meta.labels.units: 'km/s',
-    meta.labels.desc: 'Satellite velocity along ECI-z',
-    meta.labels.name: 'Satellite velocity ECI-z'}

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -49,6 +49,8 @@ def init(self):
 
     """
 
+    orbits._check_orbital_params(self.kwargs)
+
     self.acknowledgements = ' '.join((
         'The project uses the sgp4 library available at',
         'https://github.com/brandon-rhodes/python-sgp4'))

--- a/pysatMissions/tests/test_inst_methods_orbits.py
+++ b/pysatMissions/tests/test_inst_methods_orbits.py
@@ -1,0 +1,44 @@
+"""Unit tests for `pysatMissions.instruments.methods.orbits`."""
+
+import pytest
+import pysatMissions.instruments.methods.orbits as mm_orbits
+
+
+class TestBasics():
+    """Unit tests for conversion to/from Keplerian elements."""
+
+    def setup(self):
+        """Create a clean testing setup before each method."""
+        self.orbit = {'inclination': 13, 'apogee': 850, 'perigee': 400,
+                      'eccentricity': 0.032161234991424,
+                      'mean_motion': 0.0647469462135}
+        return
+
+    def teardown(self):
+        """Clean up test environment after each method."""
+        del self.orbit
+        return
+
+    def test_convert_wrong_planet(self):
+        """Test conversion routines with an unsupported planet."""
+        with pytest.raises(KeyError) as kerr:
+            mm_orbits.convert_to_keplerian(self.orbit['perigee'],
+                                           self.orbit['apogee'], 'Hwae')
+        assert str(kerr).find("is not yet a supported planet!") >= 0
+        return
+
+    def test_convert_to_keplerian(self):
+        """Test conversion to keplerian elements."""
+        ecc, mm, = mm_orbits.convert_to_keplerian(self.orbit['perigee'],
+                                                  self.orbit['apogee'],)
+        assert abs(ecc - self.orbit['eccentricity']) / ecc < 1.e-6
+        assert abs(mm - self.orbit['mean_motion']) / mm < 1.e-6
+        return
+
+    def test_convert_from_keplerian(self):
+        """Test conversion from keplerian elements."""
+        per, apo, = mm_orbits.convert_from_keplerian(self.orbit['eccentricity'],
+                                                     self.orbit['mean_motion'],)
+        assert abs(per - self.orbit['perigee']) / per < 1.e-6
+        assert abs(apo - self.orbit['apogee']) / apo < 1.e-6
+        return

--- a/pysatMissions/tests/test_inst_methods_orbits.py
+++ b/pysatMissions/tests/test_inst_methods_orbits.py
@@ -1,17 +1,17 @@
 """Unit tests for `pysatMissions.instruments.methods.orbits`."""
 
-import pytest
 import pysatMissions.instruments.methods.orbits as mm_orbits
+import pytest
 
 
-class TestBasics():
+class TestBasics(object):
     """Unit tests for conversion to/from Keplerian elements."""
 
     def setup(self):
         """Create a clean testing setup before each method."""
         self.orbit = {'inclination': 13, 'apogee': 850, 'perigee': 400,
-                      'eccentricity': 0.032161234991424,
-                      'mean_motion': 0.0647469462135}
+                      'eccentricity': 0.032160315599897085,
+                      'mean_motion': 0.06474416985702029}
         return
 
     def teardown(self):

--- a/pysatMissions/tests/test_instruments.py
+++ b/pysatMissions/tests/test_instruments.py
@@ -129,7 +129,7 @@ class TestInstruments(InstTestClass):
 
     @pytest.mark.parametrize(
         "kw_dict",
-        [{'inclination': 13, 'alt_periapsis': 400, 'alt_apoapsis': 850},
+        [{'inclination': 13, 'alt_apoapsis': 850},
          {'TLE1': '1 25544U 98067A   18135.61844383  .00002728  00000-0  48567-4 0  9998'}
          ])
     def test_sgp4_options_errors(self, kw_dict):

--- a/pysatMissions/tests/test_instruments.py
+++ b/pysatMissions/tests/test_instruments.py
@@ -92,7 +92,7 @@ class TestInstruments(InstTestClass):
     @pytest.mark.parametrize(
         "kw_dict",
         [{'inclination': 13, 'alt_periapsis': 400, 'alt_apoapsis': 850,
-          'drag_coeff': 0, 'arg_periapsis': 0., 'raan': 0., 'mean_anomaly': 0.},
+          'bstar': 0, 'arg_periapsis': 0., 'raan': 0., 'mean_anomaly': 0.},
          {'TLE1': '1 25544U 98067A   18135.61844383  .00002728  00000-0  48567-4 0  9998',
           'TLE2': '2 25544  51.6402 181.0633 0004018  88.8954  22.2246 15.54059185113452'}
          ])
@@ -125,7 +125,7 @@ class TestInstruments(InstTestClass):
     @pytest.mark.parametrize(
         "kw_dict",
         [{'inclination': 13, 'alt_periapsis': 400, 'alt_apoapsis': 850,
-          'drag_coeff': 0, 'arg_periapsis': 0., 'raan': 0., 'mean_anomaly': 0.,
+          'bstar': 0, 'arg_periapsis': 0., 'raan': 0., 'mean_anomaly': 0.,
           'TLE1': '1 25544U 98067A   18135.61844383  .00002728  00000-0  48567-4 0  9998',
           'TLE2': '2 25544  51.6402 181.0633 0004018  88.8954  22.2246 15.54059185113452'}
          ])

--- a/pysatMissions/tests/test_instruments.py
+++ b/pysatMissions/tests/test_instruments.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import numpy as np
 import tempfile
+import warnings
 
 import pytest
 
@@ -62,19 +63,20 @@ class TestInstruments(InstTestClass):
         # to point to their own subpackage location, e.g.,
         # self.inst_loc = mypackage.instruments
         self.inst_loc = pysatMissions.instruments
+        self.stime = pysatMissions.instruments.missions_sgp4._test_dates['']['']
 
     def teardown_class(self):
         """Runs once to clean up testing from this class."""
         pysat.params.data['data_dirs'] = self.saved_path
         self.tempdir.cleanup()
-        del self.inst_loc, self.saved_path, self.tempdir
+        del self.inst_loc, self.saved_path, self.tempdir, self.stime
 
     # Custom package unit tests can be added here
 
     @pytest.mark.parametrize("inst_dict", [x for x in instruments['download']])
     @pytest.mark.parametrize("kwarg,output", [(None, 1), ('10s', 10)])
     def test_inst_cadence(self, inst_dict, kwarg, output):
-        """Test operation of cadence keyword, including default behavior"""
+        """Test operation of cadence keyword, including default behavior."""
 
         if kwarg:
             self.test_inst = pysat.Instrument(
@@ -83,6 +85,57 @@ class TestInstruments(InstTestClass):
             self.test_inst = pysat.Instrument(
                 inst_module=inst_dict['inst_module'])
 
-        self.test_inst.load(2019, 1)
+        self.test_inst.load(date=self.stime)
         cadence = np.diff(self.test_inst.data.index.to_pydatetime())
         assert np.all(cadence == dt.timedelta(seconds=output))
+
+    @pytest.mark.parametrize(
+        "kw_dict",
+        [{'inclination': 13, 'alt_periapsis': 400, 'alt_apoapsis': 850,
+          'drag_coeff': 0, 'arg_periapsis': 0., 'raan': 0., 'mean_anomaly': 0.},
+         {'TLE1': '1 25544U 98067A   18135.61844383  .00002728  00000-0  48567-4 0  9998',
+          'TLE2': '2 25544  51.6402 181.0633 0004018  88.8954  22.2246 15.54059185113452'}
+         ])
+    def test_sgp4_options(self, kw_dict):
+        """Test optional keywords for sgp4."""
+
+        target = 'Fake Data to be cleared'
+        self.test_inst = pysat.Instrument(
+            inst_module=pysatMissions.instruments.missions_sgp4,
+            **kw_dict)
+        self.test_inst.data = [target]
+        self.test_inst.load(date=self.stime)
+        # If target is cleared, load has run successfully
+        assert target not in self.test_inst.data
+
+    @pytest.mark.parametrize(
+        "kw_dict",
+        [{'inclination': 13, 'alt_periapsis': 400, 'alt_apoapsis': 850},
+         {'TLE1': '1 25544U 98067A   18135.61844383  .00002728  00000-0  48567-4 0  9998'}
+         ])
+    def test_sgp4_options_errors(self, kw_dict):
+        """Test optional keyword combos for sgp4 that generate errors."""
+
+        with pytest.raises(KeyError) as kerr:
+            self.test_inst = pysat.Instrument(
+                inst_module=pysatMissions.instruments.missions_sgp4,
+                **kw_dict)
+        assert str(kerr).find('Insufficient kwargs') >= 0
+
+    @pytest.mark.parametrize(
+        "kw_dict",
+        [{'inclination': 13, 'alt_periapsis': 400, 'alt_apoapsis': 850,
+          'drag_coeff': 0, 'arg_periapsis': 0., 'raan': 0., 'mean_anomaly': 0.,
+          'TLE1': '1 25544U 98067A   18135.61844383  .00002728  00000-0  48567-4 0  9998',
+          'TLE2': '2 25544  51.6402 181.0633 0004018  88.8954  22.2246 15.54059185113452'}
+         ])
+    def test_sgp4_options_warnings(self, kw_dict):
+        """Test optional keyword combos for sgp4 that generate warnings."""
+
+        with warnings.catch_warnings(record=True) as war:
+            self.test_inst = pysat.Instrument(
+                inst_module=pysatMissions.instruments.missions_sgp4,
+                **kw_dict)
+        assert len(war) >= 1
+        categories = [war[j].category for j in range(0, len(war))]
+        assert UserWarning in categories

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ numpy
 pandas
 pysat>=3.0
 pyEphem
-sgp4
+sgp4>=2.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
   pandas
   pysat>=3.0
   pyEphem
-  sgp4
+  sgp4>=2.7
 
 
 [coverage:report]


### PR DESCRIPTION
# Description

Addresses #61, and #55 (partial); Replaces #8

Adds Keplerian inputs to the sgp4 object to streamline the user interface and bypass TLEs.
- Includes several method functions to convert between altitude of perigee / apogee and eccentricity / mean_motion
- Includes array calculation of orbits to speed things up
- Adds version limits on sgp4 (>=2.7) [Current version is 2.20]
- Improves generation of metadata for missions_sgp4
- Removed unused kwargs from missions_sgp4

NOTE: the array generation routine produces slight differences in the orbital propagation, on the order of 20 cm, versus the previous version.

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Assuming module is registered:
```
import numpy as np
import pysat
from pysatMissions.instruments.methods import orbits

from sgp4.earth_gravity import wgs72
from sgp4.io import twoline2rv

# TLEs (Two Line Elements for ISS)
# format of TLEs is fixed and available from wikipedia...
line1 = '1 25544U 98067A   18001.00000000  .00002728  00000-0  48567-4 0  9998'
line2 = '2 25544  51.6402 181.0633 0004018  88.8954  22.2246 15.54059185113452'

# Use sgp4 to extract Keplerian elements from TLEs
satellite = twoline2rv(line1, line2, wgs72)

# Define object old school, using TLEs
old = pysat.Instrument('missions', 'sgp4', TLE1=line1, TLE2=line2,
                       num_samples=86400)

# Grab altitude of perigee, apogee from new conversion routines
alt_periapsis, alt_apoapsis = orbits.convert_from_keplerian(satellite.ecco,
                                                            satellite.no_kozai)

# Calculate using new routines.  Note that input should be in degrees
new = pysat.Instrument('missions', 'sgp4',
                       alt_periapsis=alt_periapsis,
                       alt_apoapsis=alt_apoapsis,
                       inclination=np.degrees(satellite.inclo),
                       bstar=satellite.bstar,
                       arg_periapsis=np.degrees(satellite.argpo),
                       raan=np.degrees(satellite.nodeo),
                       mean_anomaly=np.degrees(satellite.mo),
                       num_samples=86400)

# Load a day of each, inspect the difference
old.load(2018, 1)
new.load(2018, 1)
diff = new.data - old.data
```
Difference in position for test cases better than microns in each dimension.

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: python 3.8.2
* Any details about your local setup that are relevant: sgp4 2.20

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
