### PR TITLE
DOC/TST: Add docstring testing / improve docstrings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         python -c "import pysat; pysat.params['data_dirs'] = 'pysatData'"
 
     - name: Test PEP8 compliance
-      run: flake8 . --count --select=E,F,W --show-source --statistics
+      run: flake8 . --count --select=D,E,F,W --show-source --statistics
 
     - name: Evaluate complexity
       run: flake8 . --count --exit-zero --max-complexity=10 --statistics

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         python -c "import pysat; pysat.params['data_dirs'] = 'pysatData'"
 
     - name: Test PEP8 compliance
-      run: flake8 . --count --select=D,E,F,W --show-source --statistics
+      run: flake8 . --count --select=D,E,F,H,W --show-source --statistics
 
     - name: Evaluate complexity
       run: flake8 . --count --exit-zero --max-complexity=10 --statistics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.0] - XXXX-XX-XX
+* Documentation
+  * Improve docstrings throughout
+* Testing
+  * Add style check for docstrings
+
 ## [0.2.2] - 2021-06-18
 * Migrate pyglow interface to pysatIncubator
 * Style updates for consistency with pysat 3.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
-#
-# Configuration file for the Sphinx documentation builder.
-#
-# This file does only contain a selection of the most common options. For a
-# full list see the documentation:
-# https://www.sphinx-doc.org/en/master/config
+
+"""Configuration file for the Sphinx documentation builder.
+
+Note
+----
+For a full list see the documentation:
+https://www.sphinx-doc.org/en/master/config
+
+"""
 
 # -- Path setup --------------------------------------------------------------
 

--- a/pysatMissions/__init__.py
+++ b/pysatMissions/__init__.py
@@ -1,5 +1,19 @@
-from __future__ import print_function
-from __future__ import absolute_import
+"""
+Core library for pysatMissions.
+
+pysatMissions allows users to run build simulated satellites for Two-Line
+Elements (TLE) and add empirical data.  It includes the `missions_ephem` and
+`mission_sgp4` instrument modules which can be imported into pysat.
+
+Main Features
+-------------
+- Simulate satellite orbits from TLEs and add data from empirical models
+- Import ionosphere and thermosphere model values through pyglow
+- Import magnetic coordinates through apexpy and aacgmv2
+- Import geomagnetic basis vectors through OMMBV
+
+"""
+
 import logging
 import os
 

--- a/pysatMissions/__init__.py
+++ b/pysatMissions/__init__.py
@@ -1,5 +1,4 @@
-"""
-Core library for pysatMissions.
+"""Core library for pysatMissions.
 
 pysatMissions allows users to run build simulated satellites for Two-Line
 Elements (TLE) and add empirical data.  It includes the `missions_ephem` and

--- a/pysatMissions/instruments/__init__.py
+++ b/pysatMissions/instruments/__init__.py
@@ -1,6 +1,5 @@
 """
-pysatMissions.instruments is a pysat module that provides
-the instrument modules to be used with pysat
+Provides the instrument modules to be used with pysat.
 """
 
 from pysatMissions.instruments import missions_ephem, missions_sgp4

--- a/pysatMissions/instruments/__init__.py
+++ b/pysatMissions/instruments/__init__.py
@@ -1,5 +1,6 @@
 """Provides the instrument modules to be used with pysat."""
 
-from pysatMissions.instruments import missions_ephem, missions_sgp4
+from pysatMissions.instruments import missions_ephem
+from pysatMissions.instruments import missions_sgp4
 
 __all__ = ['missions_ephem', 'missions_sgp4']

--- a/pysatMissions/instruments/__init__.py
+++ b/pysatMissions/instruments/__init__.py
@@ -1,6 +1,4 @@
-"""
-Provides the instrument modules to be used with pysat.
-"""
+"""Provides the instrument modules to be used with pysat."""
 
 from pysatMissions.instruments import missions_ephem, missions_sgp4
 

--- a/pysatMissions/instruments/_core.py
+++ b/pysatMissions/instruments/_core.py
@@ -1,10 +1,15 @@
 """
-Handles the default pysat functions for simulated instruments
+Handles the default pysat functions for simulated instruments.
 """
 
 
 def _clean(self):
-    """Cleaning function.  Simple pass since data is generated locally.
+    """Pass through since cleaning is not needed.
+
+    Note
+    ----
+    Required for pysat standards compliance.
+
     """
 
     return

--- a/pysatMissions/instruments/_core.py
+++ b/pysatMissions/instruments/_core.py
@@ -1,6 +1,4 @@
-"""
-Handles the default pysat functions for simulated instruments.
-"""
+"""Handles the default pysat functions for simulated instruments."""
 
 
 def _clean(self):

--- a/pysatMissions/instruments/missions_ephem.py
+++ b/pysatMissions/instruments/missions_ephem.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Produce satellite orbit data.
+"""Produce satellite orbit data.
 
 Orbit is simulated using Two Line Elements (TLEs) and ephem. Satellite position
 is coupled to several space science models to simulate the atmosphere the
@@ -48,8 +47,7 @@ _test_dates = {'': {'': dt.datetime(2018, 1, 1)}}
 
 
 def init(self):
-    """
-    Add custom calculations to orbit simulation.
+    """Add custom calculations to orbit simulation.
 
     This routine is run once, and only once, upon instantiation.
     Adds custom routines for quasi-dipole coordinates, velocity calculation in
@@ -68,8 +66,7 @@ def init(self):
 
 
 def preprocess(self):
-    """
-    Add modeled magnetic field values and attitude vectors to spacecraft.
+    """Add modeled magnetic field values and attitude vectors to spacecraft.
 
     Runs after load is invoked.
 
@@ -89,8 +86,7 @@ clean = mcore._clean
 
 def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
          TLE1=None, TLE2=None, num_samples=None, cadence='1S'):
-    """
-    Generate position of satellite in both geographic and ECEF co-ordinates.
+    """Generate position of satellite in both geographic and ECEF co-ordinates.
 
     Note
     ----

--- a/pysatMissions/instruments/missions_ephem.py
+++ b/pysatMissions/instruments/missions_ephem.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """
-Produces satellite orbit data. Orbit is simulated using
-Two Line Elements (TLEs) and ephem. Satellite position is coupled
-to several space science models to simulate the atmosphere the
+Produce satellite orbit data.
+
+Orbit is simulated using Two Line Elements (TLEs) and ephem. Satellite position
+is coupled to several space science models to simulate the atmosphere the
 satellite is in.
 
 Properties
@@ -21,9 +22,13 @@ inst_id
 import datetime as dt
 import functools
 import numpy as np
+import sys
 
 import ephem
-import OMMBV
+try:
+    import OMMBV
+except ImportError:
+    pass
 import pandas as pds
 import pysat
 
@@ -48,9 +53,9 @@ _test_dates = {'': {'': dt.datetime(2018, 1, 1)}}
 
 def init(self):
     """
-    Adds custom calculations to orbit simulation.
-    This routine is run once, and only once, upon instantiation.
+    Add custom calculations to orbit simulation.
 
+    This routine is run once, and only once, upon instantiation.
     Adds custom routines for quasi-dipole coordinates, velocity calculation in
     ECEF coords, and attitude vectors of spacecraft (assuming x is ram pointing
     and z is generally nadir).
@@ -68,7 +73,7 @@ def init(self):
 
 def preprocess(self):
     """
-    Add modeled magnetic field values and attitude vectors to spacecraft
+    Add modeled magnetic field values and attitude vectors to spacecraft.
 
     Runs after load is invoked.
 
@@ -89,9 +94,10 @@ clean = mcore._clean
 def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
          TLE1=None, TLE2=None, num_samples=None, cadence='1S'):
     """
-    Returns data and metadata in the format required by pysat. Generates
-    position of satellite in both geographic and ECEF co-ordinates.
+    Generate position of satellite in both geographic and ECEF co-ordinates.
 
+    Note
+    ----
     Routine is directly called by pysat and not the user.
 
     Parameters
@@ -192,9 +198,10 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
         lp['alt'] = sat.elevation / 1000.0
 
         # Get ECEF position of satellite
-        lp['x'], lp['y'], lp['z'] = OMMBV.geodetic_to_ecef(lp['glat'],
-                                                           lp['glong'],
-                                                           lp['alt'])
+        if "OMMBV" in sys.modules:
+            lp['x'], lp['y'], lp['z'] = OMMBV.geodetic_to_ecef(lp['glat'],
+                                                               lp['glong'],
+                                                               lp['alt'])
         output_params.append(lp)
 
     output = pds.DataFrame(output_params, index=index)

--- a/pysatMissions/instruments/missions_ephem.py
+++ b/pysatMissions/instruments/missions_ephem.py
@@ -22,13 +22,9 @@ inst_id
 import datetime as dt
 import functools
 import numpy as np
-import sys
 
 import ephem
-try:
-    import OMMBV
-except ImportError:
-    pass
+import OMMBV
 import pandas as pds
 import pysat
 
@@ -198,10 +194,9 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
         lp['alt'] = sat.elevation / 1000.0
 
         # Get ECEF position of satellite
-        if "OMMBV" in sys.modules:
-            lp['x'], lp['y'], lp['z'] = OMMBV.geodetic_to_ecef(lp['glat'],
-                                                               lp['glong'],
-                                                               lp['alt'])
+        lp['x'], lp['y'], lp['z'] = OMMBV.geodetic_to_ecef(lp['glat'],
+                                                           lp['glong'],
+                                                           lp['alt'])
         output_params.append(lp)
 
     output = pds.DataFrame(output_params, index=index)

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -164,7 +164,7 @@ def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
                          index=index)
     data.index.name = 'Epoch'
 
-    # TODO: add call for GEI/ECEF translation here => #56
+    # TODO(#56): add call for GEI/ECEF translation here
 
     return data, meta.copy()
 

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Produce satellite orbit data.
+"""Produce satellite orbit data.
 
 Orbit is simulated using Two Line Elements (TLEs) and SGP4.
 
@@ -66,8 +65,7 @@ clean = mcore._clean
 
 def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
          TLE1=None, TLE2=None, num_samples=None, cadence='1S'):
-    """
-    Generate position of satellite in ECI co-ordinates.
+    """Generate position of satellite in ECI co-ordinates.
 
     Note
     ----

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-Produces satellite orbit data. Orbit is simulated using
-Two Line Elements (TLEs) and SGP4.
+Produce satellite orbit data.
+
+Orbit is simulated using Two Line Elements (TLEs) and SGP4.
 
 Properties
 ----------
@@ -40,7 +41,7 @@ _test_dates = {'': {'': dt.datetime(2018, 1, 1)}}
 
 def init(self):
     """
-    Initializes the Instrument object with required values.
+    Initialize the Instrument object with required values.
 
     Runs once upon instantiation.
 
@@ -66,9 +67,10 @@ clean = mcore._clean
 def load(fnames, tag=None, inst_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
          TLE1=None, TLE2=None, num_samples=None, cadence='1S'):
     """
-    Returns data and metadata in the format required by pysat. Generates
-    position of satellite in ECI co-ordinates.
+    Generate position of satellite in ECI co-ordinates.
 
+    Note
+    ----
     Routine is directly called by pysat and not the user.
 
     Parameters

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -39,8 +39,7 @@ _test_dates = {'': {'': dt.datetime(2018, 1, 1)}}
 
 
 def init(self):
-    """
-    Initialize the Instrument object with required values.
+    """Initialize the Instrument object with required values.
 
     Runs once upon instantiation.
 

--- a/pysatMissions/methods/__init__.py
+++ b/pysatMissions/methods/__init__.py
@@ -1,6 +1,4 @@
-"""
-Provides the methods to interface with numerous empirical model packages.
-"""
+"""Provides the methods to interface with numerous empirical model packages."""
 
 from pysatMissions.methods import magcoord
 from pysatMissions.methods import spacecraft

--- a/pysatMissions/methods/__init__.py
+++ b/pysatMissions/methods/__init__.py
@@ -1,6 +1,5 @@
 """
-pysatMissions.methods is a module that provides
-the methods to interface with numerous empirical model packages
+Provides the methods to interface with numerous empirical model packages.
 """
 
 from pysatMissions.methods import magcoord

--- a/pysatMissions/methods/magcoord.py
+++ b/pysatMissions/methods/magcoord.py
@@ -9,7 +9,7 @@ import apexpy
 def add_aacgm_coordinates(inst, glat_label='glat', glong_label='glong',
                           alt_label='alt'):
     """
-    Add AACGM coordinates to instrument object via AACGMV2 package.
+    Add AACGM coordinates to instrument object using AACGMV2 package.
 
     The Altitude Adjusted Corrected Geomagnetic Coordinates library is used
     to calculate the latitude, longitude, and local time

--- a/pysatMissions/methods/magcoord.py
+++ b/pysatMissions/methods/magcoord.py
@@ -8,8 +8,7 @@ import apexpy
 
 def add_aacgm_coordinates(inst, glat_label='glat', glong_label='glong',
                           alt_label='alt'):
-    """
-    Add AACGM coordinates to instrument object using AACGMV2 package.
+    """Add AACGM coordinates to instrument object using AACGMV2 package.
 
     The Altitude Adjusted Corrected Geomagnetic Coordinates library is used
     to calculate the latitude, longitude, and local time
@@ -69,8 +68,7 @@ def add_aacgm_coordinates(inst, glat_label='glat', glong_label='glong',
 
 def add_quasi_dipole_coordinates(inst, glat_label='glat', glong_label='glong',
                                  alt_label='alt'):
-    """
-    Add quasi-dipole coordinates to instrument object using Apexpy package.
+    """Add quasi-dipole coordinates to instrument object using Apexpy package.
 
     The Quasi-Dipole coordinate system includes both the tilt and offset of the
     geomagnetic field to calculate the latitude, longitude, and local time

--- a/pysatMissions/methods/magcoord.py
+++ b/pysatMissions/methods/magcoord.py
@@ -1,6 +1,5 @@
-"""Provides default routines for projecting aacgmv2 and apexpy model values onto
-locations from pysat instruments.
-
+"""
+Routines for projecting aacgmv2 and apexpy model values onto pysat instruments.
 """
 
 import aacgmv2
@@ -10,7 +9,7 @@ import apexpy
 def add_aacgm_coordinates(inst, glat_label='glat', glong_label='glong',
                           alt_label='alt'):
     """
-    Uses AACGMV2 package to add AACGM coordinates to instrument object.
+    Add AACGM coordinates to instrument object via AACGMV2 package.
 
     The Altitude Adjusted Corrected Geomagnetic Coordinates library is used
     to calculate the latitude, longitude, and local time
@@ -71,7 +70,7 @@ def add_aacgm_coordinates(inst, glat_label='glat', glong_label='glong',
 def add_quasi_dipole_coordinates(inst, glat_label='glat', glong_label='glong',
                                  alt_label='alt'):
     """
-    Uses Apexpy package to add quasi-dipole coordinates to instrument object.
+    Add quasi-dipole coordinates to instrument object using Apexpy package.
 
     The Quasi-Dipole coordinate system includes both the tilt and offset of the
     geomagnetic field to calculate the latitude, longitude, and local time

--- a/pysatMissions/methods/spacecraft.py
+++ b/pysatMissions/methods/spacecraft.py
@@ -1,5 +1,4 @@
-"""Provides default routines for projecting values onto vectors
-for pysat instruments.
+"""Default routines for projecting values onto vectors for pysat instruments.
 
 """
 
@@ -136,7 +135,7 @@ def add_ram_pointing_sc_attitude_vectors(inst):
 
 def calculate_ecef_velocity(inst):
     """
-    Calculates spacecraft velocity in ECEF frame.
+    Calculate spacecraft velocity in ECEF frame.
 
     Presumes that the spacecraft velocity in ECEF is in
     the input instrument object as position_ecef_*. Uses a symmetric
@@ -187,7 +186,7 @@ def calculate_ecef_velocity(inst):
 def project_ecef_vector_onto_sc(inst, x_label, y_label, z_label,
                                 new_x_label, new_y_label, new_z_label,
                                 meta=None):
-    """Express input vector using s/c attitude directions
+    """Express input vector using s/c attitude directions.
 
     x - ram pointing
     y - generally southward

--- a/pysatMissions/methods/spacecraft.py
+++ b/pysatMissions/methods/spacecraft.py
@@ -206,7 +206,7 @@ def project_ecef_vector_onto_sc(inst, x_label, y_label, z_label,
         Dicts contain metadata to be assigned.
     """
 
-    # TODO: add checks for existence of ecef labels in inst => #65
+    # TODO(#65): add checks for existence of ecef labels in inst
 
     x, y, z = OMMBV.project_ecef_vector_onto_basis(
         inst[x_label], inst[y_label], inst[z_label],

--- a/pysatMissions/methods/spacecraft.py
+++ b/pysatMissions/methods/spacecraft.py
@@ -206,7 +206,7 @@ def project_ecef_vector_onto_sc(inst, x_label, y_label, z_label,
         Dicts contain metadata to be assigned.
     """
 
-    # TODO: add checks for existence of ecef labels in inst
+    # TODO: add checks for existence of ecef labels in inst => #65
 
     x, y, z = OMMBV.project_ecef_vector_onto_basis(
         inst[x_label], inst[y_label], inst[z_label],

--- a/pysatMissions/methods/spacecraft.py
+++ b/pysatMissions/methods/spacecraft.py
@@ -1,14 +1,11 @@
-"""Default routines for projecting values onto vectors for pysat instruments.
-
-"""
+"""Default routines for projecting values onto vectors for pysat instruments."""
 
 import numpy as np
 import OMMBV
 
 
 def add_ram_pointing_sc_attitude_vectors(inst):
-    """
-    Add attitude vectors for spacecraft assuming ram pointing.
+    """Add attitude vectors for spacecraft assuming ram pointing.
 
     Presumes spacecraft is pointed along the velocity vector (x), z is
     generally nadir pointing (positive towards Earth), and y completes the
@@ -134,8 +131,7 @@ def add_ram_pointing_sc_attitude_vectors(inst):
 
 
 def calculate_ecef_velocity(inst):
-    """
-    Calculate spacecraft velocity in ECEF frame.
+    """Calculate spacecraft velocity in ECEF frame.
 
     Presumes that the spacecraft velocity in ECEF is in
     the input instrument object as position_ecef_*. Uses a symmetric

--- a/pysatMissions/tests/__init__.py
+++ b/pysatMissions/tests/__init__.py
@@ -1,1 +1,20 @@
-"""Unit and Integration tests for pysatMissions."""
+"""Unit and Integration tests for pysatMissions.
+
+Note
+----
+This file must remain empty of code for pytest to function.
+
+Example
+-------
+To run all tests:
+::
+
+  pytest
+
+ To run a specific test, include the filename (with the full path if not in the
+ test directory), class, and test name:
+ ::
+
+   pytest test_instruments.py::TestInstruments::test_inst_cadence
+
+"""

--- a/pysatMissions/tests/__init__.py
+++ b/pysatMissions/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit and Integration tests for pysatMissions."""

--- a/pysatMissions/tests/test_instruments.py
+++ b/pysatMissions/tests/test_instruments.py
@@ -18,8 +18,8 @@ import pysat
 import pysatMissions
 
 # Import the test classes from pysat
-from pysat.utils import generate_instrument_list
 from pysat.tests.instrument_test_class import InstTestClass
+from pysat.utils import generate_instrument_list
 
 
 saved_path = pysat.params['data_dirs']

--- a/pysatMissions/tests/test_instruments.py
+++ b/pysatMissions/tests/test_instruments.py
@@ -66,6 +66,7 @@ class TestInstruments(InstTestClass):
 
     def setup_class(self):
         """Initialize the testing setup once before all tests are run."""
+
         # Make sure to use a temporary directory so that the user's setup is not
         # altered
         self.tempdir = tempfile.TemporaryDirectory()
@@ -79,6 +80,7 @@ class TestInstruments(InstTestClass):
 
     def teardown_class(self):
         """Clean up downloaded files and parameters from tests."""
+
         pysat.params.data['data_dirs'] = self.saved_path
         self.tempdir.cleanup()
         del self.inst_loc, self.saved_path, self.tempdir

--- a/pysatMissions/tests/test_instruments.py
+++ b/pysatMissions/tests/test_instruments.py
@@ -1,3 +1,12 @@
+"""
+Unit and Integration Tests for each instrument module.
+
+Note
+----
+Imports test methods from pysat.tests.instrument_test_class
+
+"""
+
 import datetime as dt
 import numpy as np
 import tempfile
@@ -46,13 +55,18 @@ for method in method_list:
 
 
 class TestInstruments(InstTestClass):
-    """Uses class level setup and teardown so that all tests use the same
+    """Main class for instrument tests.
+
+    Note
+    ----
+    Uses class level setup and teardown so that all tests use the same
     temporary directory. We do not want to geneate a new tempdir for each test,
     as the load tests need to be the same as the download tests.
+
     """
 
     def setup_class(self):
-        """Runs once before the tests to initialize the testing setup."""
+        """Initialize the testing setup once before all tests are run."""
         # Make sure to use a temporary directory so that the user's setup is not
         # altered
         self.tempdir = tempfile.TemporaryDirectory()
@@ -64,7 +78,7 @@ class TestInstruments(InstTestClass):
         self.inst_loc = pysatMissions.instruments
 
     def teardown_class(self):
-        """Runs once to clean up testing from this class."""
+        """Clean up downloaded files and parameters from tests."""
         pysat.params.data['data_dirs'] = self.saved_path
         self.tempdir.cleanup()
         del self.inst_loc, self.saved_path, self.tempdir
@@ -74,7 +88,7 @@ class TestInstruments(InstTestClass):
     @pytest.mark.parametrize("inst_dict", [x for x in instruments['download']])
     @pytest.mark.parametrize("kwarg,output", [(None, 1), ('10s', 10)])
     def test_inst_cadence(self, inst_dict, kwarg, output):
-        """Test operation of cadence keyword, including default behavior"""
+        """Test operation of cadence keyword, including default behavior."""
 
         if kwarg:
             self.test_inst = pysat.Instrument(

--- a/pysatMissions/tests/test_instruments.py
+++ b/pysatMissions/tests/test_instruments.py
@@ -1,5 +1,4 @@
-"""
-Unit and Integration Tests for each instrument module.
+"""Unit and Integration Tests for each instrument module.
 
 Note
 ----

--- a/pysatMissions/tests/test_instruments.py
+++ b/pysatMissions/tests/test_instruments.py
@@ -75,12 +75,14 @@ class TestInstruments(InstTestClass):
         # to point to their own subpackage location, e.g.,
         # self.inst_loc = mypackage.instruments
         self.inst_loc = pysatMissions.instruments
+        return
 
     def teardown_class(self):
         """Clean up downloaded files and parameters from tests."""
         pysat.params.data['data_dirs'] = self.saved_path
         self.tempdir.cleanup()
         del self.inst_loc, self.saved_path, self.tempdir
+        return
 
     # Custom package unit tests can be added here
 
@@ -99,3 +101,4 @@ class TestInstruments(InstTestClass):
         self.test_inst.load(2019, 1)
         cadence = np.diff(self.test_inst.data.index.to_pydatetime())
         assert np.all(cadence == dt.timedelta(seconds=output))
+        return

--- a/pysatMissions/tests/test_methods_magcoord.py
+++ b/pysatMissions/tests/test_methods_magcoord.py
@@ -7,7 +7,7 @@ import pysat
 import pysatMissions.methods.magcoord as mm_magcoord
 
 
-class TestBasics():
+class TestBasics(object):
     """Main testing class for aacgmv2."""
 
     def setup(self):

--- a/pysatMissions/tests/test_methods_magcoord.py
+++ b/pysatMissions/tests/test_methods_magcoord.py
@@ -14,10 +14,12 @@ class TestBasics():
         """Create a clean testing setup before each method."""
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          num_samples=100, clean_level='clean')
+        return
 
     def teardown(self):
         """Clean up test environment after each method."""
         del self
+        return
 
     def test_add_aacgm_coordinates(self):
         """Test adding thermal plasma data to test inst."""
@@ -33,6 +35,7 @@ class TestBasics():
             assert not np.isnan(self.testInst[target]).any()
             # Check if metadata is added
             assert target in self.testInst.meta.data.index
+        return
 
     def test_add_quasi_dipole_coordinates(self):
         """Test adding thermal plasma data to test inst."""
@@ -48,3 +51,4 @@ class TestBasics():
             assert not np.isnan(self.testInst[target]).any()
             # Check if metadata is added
             assert target in self.testInst.meta.data.index
+        return

--- a/pysatMissions/tests/test_methods_magcoord.py
+++ b/pysatMissions/tests/test_methods_magcoord.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Test some of the aacgmv2 method functions
+"""Test some of the aacgmv2 method functions."""
 
 import datetime as dt
 import numpy as np
@@ -8,17 +8,19 @@ import pysatMissions.methods.magcoord as mm_magcoord
 
 
 class TestBasics():
+    """Main testing class for aacgmv2."""
+
     def setup(self):
-        """Runs before every method to create a clean testing setup."""
+        """Create a clean testing setup before each method."""
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          num_samples=100, clean_level='clean')
 
     def teardown(self):
-        """Clean up test environment after tests"""
+        """Clean up test environment after each method."""
         del self
 
     def test_add_aacgm_coordinates(self):
-        """Test adding thermal plasma data to test inst"""
+        """Test adding thermal plasma data to test inst."""
         self.testInst.custom_attach(mm_magcoord.add_aacgm_coordinates,
                                     kwargs={'glat_label': 'latitude',
                                             'glong_label': 'longitude',
@@ -33,7 +35,7 @@ class TestBasics():
             assert target in self.testInst.meta.data.index
 
     def test_add_quasi_dipole_coordinates(self):
-        """Test adding thermal plasma data to test inst"""
+        """Test adding thermal plasma data to test inst."""
         self.testInst.custom_attach(mm_magcoord.add_quasi_dipole_coordinates,
                                     kwargs={'glat_label': 'latitude',
                                             'glong_label': 'longitude',

--- a/pysatMissions/tests/test_methods_spacecraft.py
+++ b/pysatMissions/tests/test_methods_spacecraft.py
@@ -23,7 +23,7 @@ def add_eci(inst):
 
 
 def add_fake_data(inst):
-    """Add arbitrary vector to pysat_testing instrument."""
+    """Add an arbitrary vector to a pysat_testing instrument."""
 
     inst['ax'] = np.ones(9)
     inst['ay'] = np.zeros(9)

--- a/pysatMissions/tests/test_methods_spacecraft.py
+++ b/pysatMissions/tests/test_methods_spacecraft.py
@@ -68,7 +68,7 @@ class TestBasics():
     def test_add_ram_pointing_sc_attitude_vectors(self):
         """Test `add_ram_pointing_sc_attitude_vectors` helper function."""
 
-        # TODO: check if calculations are correct
+        # TODO: check if calculations are correct => #64
         self.testInst.custom_attach(mm_sc.calculate_ecef_velocity)
         self.testInst.custom_attach(mm_sc.add_ram_pointing_sc_attitude_vectors)
         self.testInst.load(date=dt.datetime(2009, 1, 1))
@@ -89,7 +89,7 @@ class TestBasics():
     def test_project_ecef_vector_onto_sc(self):
         """Test `project_ecef_vector_onto_sc` helper function."""
 
-        # TODO: check if calculations are correct
+        # TODO: check if calculations are correct => #64
         self.testInst.custom_attach(mm_sc.calculate_ecef_velocity)
         self.testInst.custom_attach(mm_sc.add_ram_pointing_sc_attitude_vectors)
         self.testInst.custom_attach(add_fake_data)

--- a/pysatMissions/tests/test_methods_spacecraft.py
+++ b/pysatMissions/tests/test_methods_spacecraft.py
@@ -68,7 +68,7 @@ class TestBasics():
     def test_add_ram_pointing_sc_attitude_vectors(self):
         """Test `add_ram_pointing_sc_attitude_vectors` helper function."""
 
-        # TODO: check if calculations are correct => #64
+        # TODO(#64): check if calculations are correct
         self.testInst.custom_attach(mm_sc.calculate_ecef_velocity)
         self.testInst.custom_attach(mm_sc.add_ram_pointing_sc_attitude_vectors)
         self.testInst.load(date=dt.datetime(2009, 1, 1))
@@ -89,7 +89,7 @@ class TestBasics():
     def test_project_ecef_vector_onto_sc(self):
         """Test `project_ecef_vector_onto_sc` helper function."""
 
-        # TODO: check if calculations are correct => #64
+        # TODO(#64): check if calculations are correct
         self.testInst.custom_attach(mm_sc.calculate_ecef_velocity)
         self.testInst.custom_attach(mm_sc.add_ram_pointing_sc_attitude_vectors)
         self.testInst.custom_attach(add_fake_data)

--- a/pysatMissions/tests/test_methods_spacecraft.py
+++ b/pysatMissions/tests/test_methods_spacecraft.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Test some of the spacecraft method functions
+"""Test some of the spacecraft method functions."""
 
 import datetime as dt
 import numpy as np
@@ -8,7 +8,7 @@ from pysatMissions.methods import spacecraft as mm_sc
 
 
 def add_eci(inst):
-    """Add ECI position to pysat_testing instrument"""
+    """Add ECI position to pysat_testing instrument."""
 
     inst['position_ecef_x'] = [-6197.135721, -6197.066687, -6196.990263,
                                -6196.906991, -6196.816336, -6196.718347,
@@ -19,26 +19,38 @@ def add_eci(inst):
     inst['position_ecef_z'] = [1716.528241, 1710.870004, 1705.209738,
                                1699.547245, 1693.882731, 1688.216005,
                                1682.547257, 1676.876312, 1671.203352]
+    return
 
 
 def add_fake_data(inst):
+    """Add arbitrary vector to pysat_testing instrument."""
+
     inst['ax'] = np.ones(9)
     inst['ay'] = np.zeros(9)
     inst['az'] = np.zeros(9)
+    return
 
 
 class TestBasics():
+    """Unit tests for aacgmv2 methods."""
+
     def setup(self):
-        """Runs before every method to create a clean testing setup."""
+        """Create a clean testing setup before each method."""
+
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          num_samples=9, clean_level='clean')
         self.testInst.custom_attach(add_eci)
+        return
 
     def teardown(self):
-        """Clean up test environment after tests"""
+        """Clean up test environment after tests."""
+
         del self
+        return
 
     def test_calculate_ecef_velocity(self):
+        """Test `calculate_ecef_velocity` helper function."""
+
         self.testInst.custom_attach(mm_sc.calculate_ecef_velocity)
         self.testInst.load(date=dt.datetime(2009, 1, 1))
         targets = ['velocity_ecef_x', 'velocity_ecef_y', 'velocity_ecef_z']
@@ -51,8 +63,11 @@ class TestBasics():
             assert np.isnan(self.testInst[target][-1])
             # Check if metadata is added
             assert target in self.testInst.meta.data.index
+        return
 
     def test_add_ram_pointing_sc_attitude_vectors(self):
+        """Test `add_ram_pointing_sc_attitude_vectors` helper function."""
+
         # TODO: check if calculations are correct
         self.testInst.custom_attach(mm_sc.calculate_ecef_velocity)
         self.testInst.custom_attach(mm_sc.add_ram_pointing_sc_attitude_vectors)
@@ -69,8 +84,11 @@ class TestBasics():
             assert np.isnan(self.testInst[target][-1])
             # Check if metadata is added
             assert target in self.testInst.meta.data.index
+        return
 
     def test_project_ecef_vector_onto_sc(self):
+        """Test `project_ecef_vector_onto_sc` helper function."""
+
         # TODO: check if calculations are correct
         self.testInst.custom_attach(mm_sc.calculate_ecef_velocity)
         self.testInst.custom_attach(mm_sc.add_ram_pointing_sc_attitude_vectors)
@@ -88,3 +106,4 @@ class TestBasics():
             assert np.isnan(self.testInst[target][-1])
             # Check if metadata is added
             assert target in self.testInst.meta.data.index
+        return

--- a/pysatMissions/tests/test_methods_spacecraft.py
+++ b/pysatMissions/tests/test_methods_spacecraft.py
@@ -31,7 +31,7 @@ def add_fake_data(inst):
     return
 
 
-class TestBasics():
+class TestBasics(object):
     """Unit tests for aacgmv2 methods."""
 
     def setup(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,10 @@ install_requires =
 
 [flake8]
 max-line-length = 90
-ignore = W503
+ignore =
+  D200
+  D202
+  W503
 
 [tool:pytest]
 markers =

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2021, Authors
 # Full license can be found in License.md
 # -----------------------------------------------------------------------------
+"""Setup routines for pysatMissions."""
 
 from setuptools import setup
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,9 +1,9 @@
 coveralls
+flake8-docstrings
 ipython
 m2r2
 numpydoc
 pytest-cov
-pytest-flake8
 pytest-ordering
 sphinx
 sphinx_rtd_theme

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,6 @@
 coveralls
 flake8-docstrings
+hacking
 ipython
 m2r2
 numpydoc


### PR DESCRIPTION
# Description

Uses `flake8-docstrings`  and `hacking` to check for docstring and style compliance with pysat standards.  Note that D200 and D202 are ignored as per pysat standards. Also, includes usage of `return` statements in tests and removes some python 2.7 code.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Previous pushes with non-compliant docstrings were caught by the new testing methods.

**Test Configuration**:
Github Actions

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
