### PR TITLE
DEP: missions_ephem instrument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Improve metadata generation in missions_sgp4
 * Documentation
   * Improve docstrings throughout
+* Deprecations
+  * Deprecated missions_ephem, as pyephem will no longer be updated
 * Testing
   * Add style check for docstrings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Deprecated missions_ephem, as pyephem will no longer be updated
 * Testing
   * Add style check for docstrings
+  * Added checks for deprecation warnings
 
 ## [0.2.2] - 2021-06-18
 * Migrate pyglow interface to pysatIncubator

--- a/pysatMissions/instruments/missions_ephem.py
+++ b/pysatMissions/instruments/missions_ephem.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 """Produce satellite orbit data.
 
+.. deprecated:: 0.3.0
+    pyephem is no longer updated, and the code maintainers suggest skyfield
+    as a replacement.  The functionality of the instrument will be replaced by
+    the new `missions_sgp4` instrument.  `missions_ephem` will be removed in
+    versions 0.4.0+
+
 Orbit is simulated using Two Line Elements (TLEs) and ephem. Satellite position
 is coupled to several space science models to simulate the atmosphere the
 satellite is in.
@@ -21,6 +27,7 @@ inst_id
 import datetime as dt
 import functools
 import numpy as np
+import warnings
 
 import ephem
 import OMMBV
@@ -61,6 +68,11 @@ def init(self):
         'https://github.com/brandon-rhodes/pyephem'))
     self.references = 'Please contact the pyephem project for references'
     logger.info(self.acknowledgements)
+
+    warnings.warn(' '.join(("`missions_ephem` has been deprecated and will be",
+                            "removed in pysatMissions 0.4.0+.",
+                            "Use `missions_sgp4` instead.")),
+                  DeprecationWarning, stacklevel=2)
 
     return
 

--- a/pysatMissions/tests/test_deprecation.py
+++ b/pysatMissions/tests/test_deprecation.py
@@ -1,5 +1,6 @@
 """Unit tests for deprecated methods an objects in pysatMissions."""
 
+import numpy as np
 import warnings
 
 import pysat
@@ -19,7 +20,7 @@ class TestDeprecation(object):
         """Clean up test environment after each method."""
         return
 
-    def eval_deprecation(self, warns, check_msgs):
+    def eval_deprecation(self, warns, check_msgs, warn_type=DeprecationWarning):
         """Evaluate whether message is contained in DeprecationWarning.
 
         Parameters
@@ -28,14 +29,27 @@ class TestDeprecation(object):
             List of warnings.WarningMessage objects
         check_msgs : list
             List of strings containing the expected warning messages
+        warn_type : type
+            Type for the warning messages (default=DeprecationWarning)
 
         """
 
         # Ensure the minimum number of warnings were raised
         assert len(warns) >= len(check_msgs)
 
+        # Initialize the output
+        found_msgs = [False for msg in check_msgs]
+
         # Test the warning messages, ensuring each attribute is present
-        pysat.utils.testing.eval_warnings(warns, check_msgs)
+        for iwar in warns:
+            for i, msg in enumerate(check_msgs):
+                if str(iwar.message).find(msg) >= 0:
+                    assert iwar.category == warn_type, \
+                        "bad warning type for message: {:}".format(msg)
+                    found_msgs[i] = True
+
+        assert np.all(found_msgs), "did not find {:d} expected {:}".format(
+            len(found_msgs) - np.sum(found_msgs), repr(warn_type))
         return
 
     def test_ephem_deprecation(self):

--- a/pysatMissions/tests/test_deprecation.py
+++ b/pysatMissions/tests/test_deprecation.py
@@ -1,0 +1,50 @@
+"""Unit tests for deprecated methods an objects in pysatMissions."""
+
+import warnings
+
+import pysat
+from pysatMissions.instruments import missions_ephem
+
+
+class TestDeprecation(object):
+    """Unit tests for deprecations."""
+
+    def setup(self):
+        """Create a clean testing setup before each method."""
+
+        warnings.simplefilter("always", DeprecationWarning)
+        return
+
+    def teardown(self):
+        """Clean up test environment after each method."""
+        return
+
+    def eval_deprecation(self, warns, check_msgs):
+        """Evaluate whether message is contained in DeprecationWarning.
+
+        Parameters
+        ----------
+        warns : list
+            List of warnings.WarningMessage objects
+        check_msgs : list
+            List of strings containing the expected warning messages
+
+        """
+
+        # Ensure the minimum number of warnings were raised
+        assert len(warns) >= len(check_msgs)
+
+        # Test the warning messages, ensuring each attribute is present
+        pysat.utils.testing.eval_warnings(warns, check_msgs)
+        return
+
+    def test_ephem_deprecation(self):
+        """Test that instatiating missions_ephem will give DeprecationWarning."""
+
+        with warnings.catch_warnings(record=True) as war:
+            pysat.Instrument(inst_module=missions_ephem)
+
+        warn_msgs = ["`missions_ephem` has been deprecated"]
+
+        self.eval_deprecation(war, warn_msgs)
+        return


### PR DESCRIPTION
# Description

Closes #57

Adds deprecation warning and tests to `mission_ephem`.  The `pyephem` package is no longer being updated, and the sgp4 + geospacepy seems like it does the same job in the end.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Instantiate a `missions_ephem` instrument with warnings turned on.

**Test Configuration**:
* Operating system: Mac OS 11.6.1
* Version number python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no *unexpected* warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
