### PR TITLE
BUG/ENH: sgp4 epoch

### DIFF
--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -131,7 +131,7 @@ def load(fnames, tag=None, inst_id=None, TLE1=None, TLE2=None,
     epoch : dt.datetime or NoneType
         The epoch used for calculating orbital propagation from Keplerians.
         If None, then use the first date in the file list for consistency across
-        multiple days. Note that this will be set at init. (default=None)
+        multiple days. Note that this will be set in `init`. (default=None)
     bstar : float
         Inverse of the ballistic coefficient. Used to model satellite drag.
         Measured in inverse distance (1 / earth radius).  Optional when

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -61,6 +61,9 @@ def init(self):
         'August 21–24.'))
     logger.info(self.acknowledgements)
 
+    if 'epoch' not in self.kwargs['load'].keys():
+        self.kwargs['load']['epoch'] = self.files.files.index[0]
+
     return
 
 
@@ -71,7 +74,7 @@ clean = mcore._clean
 def load(fnames, tag=None, inst_id=None, TLE1=None, TLE2=None,
          alt_periapsis=None, alt_apoapsis=None,
          inclination=None, raan=0., arg_periapsis=0., mean_anomaly=0.,
-         bstar=0., one_orbit=False, num_samples=None, cadence='1S'):
+         epoch=None, bstar=0., one_orbit=False, num_samples=None, cadence='1S'):
     """Generate position of satellite in ECI co-ordinates.
 
     Note
@@ -125,6 +128,10 @@ def load(fnames, tag=None, inst_id=None, TLE1=None, TLE2=None,
         orbital plane based on the orbital period.  Optional when instantiating
         via orbital elements.
         (default=0.)
+    epoch : dt.datetime or NoneType
+        The epoch used for calculating orbital propagation from Keplerians.
+        If None, then use the first date in the file list for consistency across
+        multiple days. Note that this will be set at init. (default=None)
     bstar : float
         Inverse of the ballistic coefficient. Used to model satellite drag.
         Measured in inverse distance (1 / earth radius).  Optional when
@@ -176,7 +183,7 @@ def load(fnames, tag=None, inst_id=None, TLE1=None, TLE2=None,
     times, index, dates = ps_meth.generate_times(fnames, num_samples,
                                                  freq=cadence)
     # Calculate epoch for orbital propagator
-    epoch = (dates[0] - dt.datetime(1949, 12, 31)).days
+    epoch_days = (epoch - dt.datetime(1949, 12, 31)).days
     jd, _ = sapi.jday(dates[0].year, dates[0].month, dates[0].day, 0, 0, 0)
 
     if inclination is not None:
@@ -185,7 +192,7 @@ def load(fnames, tag=None, inst_id=None, TLE1=None, TLE2=None,
                                                                 alt_apoapsis)
         satellite = sapi.Satrec()
         # according to module webpage, wgs72 is common
-        satellite.sgp4init(sapi.WGS72, 'i', 0, epoch, bstar, 0, 0,
+        satellite.sgp4init(sapi.WGS72, 'i', 0, epoch_days, bstar, 0, 0,
                            eccentricity, np.radians(arg_periapsis),
                            np.radians(inclination), np.radians(mean_anomaly),
                            mean_motion, np.radians(raan))

--- a/pysatMissions/tests/test_instruments.py
+++ b/pysatMissions/tests/test_instruments.py
@@ -90,7 +90,12 @@ class TestInstruments(InstTestClass):
 
     # Custom package unit tests can be added here
 
-    @pytest.mark.parametrize("kwargs", [{}, {'epoch': dt.datetime(2019, 1, 1)}])
+    @pytest.mark.parametrize("kwargs",
+                             [{},
+                              {'inclination': 20, 'alt_periapsis': 400},
+                              {'inclination': 80, 'alt_periapsis': 500,
+                               'alt_apoapsis': 600,
+                               'epoch': dt.datetime(2019, 1, 1)}])
     def test_sgp4_data_continuity(self, kwargs):
         """Test that data is continuous for sequential days.
 
@@ -101,8 +106,9 @@ class TestInstruments(InstTestClass):
         """
 
         # Define sat with custom Keplerian inputs
-        sat = pysat.Instrument('missions', 'sgp4', inclination=20,
-                               alt_periapsis=400, **kwargs)
+        sat = pysat.Instrument(
+            inst_module=pysatMissions.instruments.missions_sgp4,
+            **kwargs)
 
         # Get last 10 points of day 1
         sat.load(2018, 1)

--- a/pysatMissions/tests/test_instruments.py
+++ b/pysatMissions/tests/test_instruments.py
@@ -102,7 +102,9 @@ class TestInstruments(InstTestClass):
         Parameters
         ----------
         kwargs : dict
-            Optional kwargs to pass through.
+            Optional kwargs to pass through.  If empty, instrument will be
+            default TLEs.
+
         """
 
         # Define sat with custom Keplerian inputs
@@ -124,7 +126,8 @@ class TestInstruments(InstTestClass):
 
         # Check that the jump between days is within 3 sigma of average gradient
         del_g = np.abs(average_gradient - gradient_between_days)
-        assert np.all(del_g < (3. * std_gradient))
+        assert np.all(del_g < (3. * std_gradient)), \
+            "Gap between days outside of 3 sigma"
 
         return
 

--- a/pysatMissions/tests/test_instruments.py
+++ b/pysatMissions/tests/test_instruments.py
@@ -123,9 +123,8 @@ class TestInstruments(InstTestClass):
         gradient_between_days = day2.iloc[0] - day1.iloc[-1]
 
         # Check that the jump between days is within 3 sigma of average gradient
-        for key in average_gradient.keys():
-            del_g = np.abs(average_gradient[key] - gradient_between_days[key])
-            assert del_g < 3. * std_gradient[key]
+        del_g = np.abs(average_gradient - gradient_between_days)
+        assert np.all(del_g < (3. * std_gradient))
 
         return
 


### PR DESCRIPTION
# Description

Closes #67.  Fixes a bug where sequential days have a large discontinuity in data when Keplerian elements are used.

Adds `epoch` kwarg to `missions_sgp4` instrument.  The epoch is used to specify a datetime that corresponds to the Keplerian elements of the orbit used for propagation.

If a user does not specify an epoch, it defaults to the start of the file range for the instrument.  `epoch` will be set an instantiation.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Using code in #67 and new unit tests.

**Test Configuration**:
* Operating system: Mac OS 11.6.1
* Version number: python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes -- fixes for previous pull in same version
