### PR TITLE
TST: NEP29 framework

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,10 @@ jobs:
         numpy_ver: ["latest"]
         include:
           - python-version: "3.8"
-            numpy_ver: "1.19"
+            numpy_ver: "1.20"
             os: ubuntu-latest
 
-    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.9", "3.10"]
         os: [ubuntu-latest]
+        numpy_ver: ["latest"]
+        include:
+          - python-version: "3.8"
+            numpy_ver: "1.19"
+            os: ubuntu-latest
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -22,13 +27,22 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+
+    - name: Install requirements for testing setup
       run: |
         python -m pip install --upgrade pip
         pip install -r test_requirements.txt
+
+    - name: Install dependencies
+      run: |
         pip install -r requirements.txt
-        # Manual install of OMMBV
-        pip install --no-binary :OMMBV: OMMBV
+        # Manual install of OMMBV required for 0.5.5
+        pip install OMMBV
+
+    - name: Install NEP29 dependencies
+      if: ${{ matrix.numpy_ver != 'latest'}}
+      run: |
+        pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
 
     - name: Set up pysat
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         numpy_ver: ["latest"]
         include:
           - python-version: "3.8"
-            numpy_ver: "1.20"
+            numpy_ver: "1.19"
             os: ubuntu-latest
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}
@@ -33,16 +33,16 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r test_requirements.txt
 
+    - name: Install NEP29 dependencies
+      if: ${{ matrix.numpy_ver != 'latest'}}
+      run: |
+        pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
+
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
         # Manual install of OMMBV required for 0.5.5
         pip install OMMBV
-
-    - name: Install NEP29 dependencies
-      if: ${{ matrix.numpy_ver != 'latest'}}
-      run: |
-        pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
 
     - name: Set up pysat
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         numpy_ver: ["latest"]
         include:
           - python-version: "3.8"
-            numpy_ver: "1.19"
+            numpy_ver: "1.20"
             os: ubuntu-latest
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Improve docstrings throughout
 * Testing
   * Add style check for docstrings
+  * Include support for testing against multiple versions of numpy
 
 ## [0.2.2] - 2021-06-18
 * Migrate pyglow interface to pysatIncubator


### PR DESCRIPTION
# Description

Addresses #70

Updates python versions to test against and adds support for multiple versions of numpy in testing.  Note that minimum version is not compliant with NEP29 until June 21, 2022, when support for numpy 1.19 can be dropped.  This is because of an issue with apexpy being compiled against a different version of numpy in github actions, which appears to be a GA config issue.

Cleans up the workflow in GA a bit.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Via github actions.

**Test Configuration**:
* ubuntu
* python 3.8, 3.9, 3.10
* numpy 1.20, 1.21

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
