### PR TITLE
BUG: readthedocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Update syntax to be compliant with OMMBV 1.0
 * Documentation
   * Improve docstrings throughout
+  * Added bypass for apexpy for readthedocs build
 * Deprecations
   * Deprecated missions_ephem, as pyephem will no longer be updated
 * Testing

--- a/pysatMissions/methods/magcoord.py
+++ b/pysatMissions/methods/magcoord.py
@@ -2,7 +2,16 @@
 """
 
 import aacgmv2
-import apexpy
+import pysat
+
+try:
+    # Warn user if apexpy is not configured.  Bypass needed to function on
+    # readthedocs.
+    import apexpy
+except ImportError as ierr:
+    pysat.logger.warning("".join(["apexpy module could not be imported. ",
+                                  "apexpy interface won't work.",
+                                  "Failed with error: ", str(ierr)]))
 
 
 def add_aacgm_coordinates(inst, glat_label='glat', glong_label='glong',

--- a/pysatMissions/methods/magcoord.py
+++ b/pysatMissions/methods/magcoord.py
@@ -6,12 +6,13 @@ import pysat
 
 try:
     # Warn user if apexpy is not configured.  Bypass needed to function on
-    # readthedocs.
+    # readthedocs.  Use of apexpy functions elsewhere in code will produce
+    # errors.
     import apexpy
 except ImportError as ierr:
-    pysat.logger.warning("".join(["apexpy module could not be imported. ",
-                                  "apexpy interface won't work.",
-                                  "Failed with error: ", str(ierr)]))
+    pysat.logger.warning(" ".join(["apexpy module could not be imported.",
+                                   "apexpy interface won't work.",
+                                   "Failed with error:", str(ierr)]))
 
 
 def add_aacgm_coordinates(inst, glat_label='glat', glong_label='glong',


### PR DESCRIPTION
# Description

Readthedocs doesn't like fortran, so it fails when trying to import modules and extract the api docstrings.  This allows pysatMissions to work in a limited capacity without importing `apexpy`, similar to the bypass feature `apexpy` uses for the fortran module. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Inspection at readthedocs: https://pysatmissions.readthedocs.io/en/bug-fortran/supported_instruments.html

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
