### PR TITLE
TST/DEP: update tests for spacecraft projections, deprecate `calculate_ecef_velocity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Add manual GitHub Actions tests for optional dependencies
   * Remove optional dependencies in readthedocs requirements
   * Add tests for NEP 29 testing
+  * Deprecate `calculate_ecef_velocity` method
+* Testing
+  * Include checks on sc coordinate transformation calculations
 
 ## [0.3.3] - 2022-09-06
 * Documentation Updates

--- a/pysatMissions/methods/spacecraft.py
+++ b/pysatMissions/methods/spacecraft.py
@@ -1,6 +1,7 @@
 """Default routines for projecting values onto vectors for pysat instruments."""
 
 import numpy as np
+import warnings
 
 
 def add_ram_pointing_sc_attitude_vectors(inst):
@@ -92,6 +93,11 @@ def add_ram_pointing_sc_attitude_vectors(inst):
 def calculate_ecef_velocity(inst):
     """Calculate spacecraft velocity in ECEF frame.
 
+    .. deprecated:: 0.4.0
+      This function is no longer needed with the deprecation of `missions_ephem`.
+      Better calculations are available through geospacepy and skyfield.
+      `calculate_ecef_velocity` will be removed in versions 0.5.0+
+
     Presumes that the spacecraft velocity in ECEF is in
     the input instrument object as position_ecef_*. Uses a symmetric
     difference to calculate the velocity thus endpoints will be
@@ -110,6 +116,11 @@ def calculate_ecef_velocity(inst):
         using naming scheme velocity_ecef_* (*=x,y,z)
 
     """
+
+    warnings.warn(' '.join(("`calculate_ecef_velocity` has been deprecated and",
+                            "will be removed in pysatMissions 0.5.0+.",
+                            "Use `geospacepy` or `skyfield` instead.")),
+                  DeprecationWarning, stacklevel=2)
 
     def get_vel_from_pos(x):
         vel = (x.values[2:] - x.values[0:-2]) / 2.

--- a/pysatMissions/tests/test_methods_spacecraft.py
+++ b/pysatMissions/tests/test_methods_spacecraft.py
@@ -11,24 +11,29 @@ from pysatMissions.methods import spacecraft as mm_sc
 def add_ecef(inst):
     """Add ECEF position to pysat_testing instrument."""
 
-    inst['position_ecef_x'] = [-6197.135721, -6197.066687, -6196.990263,
-                               -6196.906991, -6196.816336, -6196.718347,
-                               -6196.613474, -6196.501303, -6196.382257]
-    inst['position_ecef_y'] = [-2169.334337, -2174.014920, -2178.693373,
-                               -2183.368212, -2188.040895, -2192.711426,
-                               -2197.378290, -2202.042988, -2206.703992]
-    inst['position_ecef_z'] = [1716.528241, 1710.870004, 1705.209738,
-                               1699.547245, 1693.882731, 1688.216005,
-                               1682.547257, 1676.876312, 1671.203352]
+    # Maintain each as unit vector to simplify checks.
+    inst['position_ecef_x'] = [0.0, 0.0, 0.0, 1.0, 1.0, 0.0]
+    inst['position_ecef_y'] = [1.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+    inst['position_ecef_z'] = [0.0, 1.0, 1.0, 0.0, 0.0, 0.0]
+    return
+
+
+def add_ecef_vel(inst):
+    """Add ECEF velocity to pysat_testing instrument."""
+
+    # Maintain each as unit vector to simplify checks.
+    inst['velocity_ecef_x'] = [1.0, 1.0, 0.0, 0.0, 0.0, 0.0]
+    inst['velocity_ecef_y'] = [0.0, 0.0, 1.0, 1.0, 0.0, 0.0]
+    inst['velocity_ecef_z'] = [0.0, 0.0, 0.0, 0.0, 1.0, 1.0]
     return
 
 
 def add_fake_data(inst):
     """Add an arbitrary vector to a pysat_testing instrument."""
 
-    inst['ax'] = np.ones(9)
-    inst['ay'] = np.zeros(9)
-    inst['az'] = np.zeros(9)
+    inst['ax'] = np.ones(6)
+    inst['ay'] = np.zeros(6)
+    inst['az'] = np.zeros(6)
     return
 
 
@@ -39,7 +44,7 @@ class TestBasics(object):
         """Create a clean testing setup before each method."""
 
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         num_samples=9, clean_level='clean',
+                                         num_samples=6, clean_level='clean',
                                          use_header=True)
         self.testInst.custom_attach(add_ecef)
         self.reftime = dt.datetime(2009, 1, 1)
@@ -76,26 +81,46 @@ class TestBasics(object):
     def test_add_ram_pointing_sc_attitude_vectors(self):
         """Test `add_ram_pointing_sc_attitude_vectors` helper function."""
 
-        # TODO(#64): check if calculations are correct
-        self.testInst.custom_attach(mm_sc.calculate_ecef_velocity)
+        self.testInst.custom_attach(add_ecef_vel)
         self.testInst.custom_attach(mm_sc.add_ram_pointing_sc_attitude_vectors)
         self.testInst.load(date=self.reftime)
-        targets = ['sc_xhat_ecef_x', 'sc_xhat_ecef_y', 'sc_xhat_ecef_z',
-                   'sc_yhat_ecef_x', 'sc_yhat_ecef_y', 'sc_yhat_ecef_z',
-                   'sc_zhat_ecef_x', 'sc_zhat_ecef_y', 'sc_zhat_ecef_z']
-        self.eval_targets(targets)
+
+        # Xhat vector should match velocity
+        assert np.all(self.testInst['sc_xhat_ecef_x']
+                      == self.testInst['velocity_ecef_x'])
+        assert np.all(self.testInst['sc_xhat_ecef_y']
+                      == self.testInst['velocity_ecef_y'])
+        assert np.all(self.testInst['sc_xhat_ecef_z']
+                      == self.testInst['velocity_ecef_z'])
+
+        # Zhat vector should match - position
+        assert np.all(self.testInst['sc_zhat_ecef_x']
+                      == -self.testInst['position_ecef_x'])
+        assert np.all(self.testInst['sc_zhat_ecef_y']
+                      == -self.testInst['position_ecef_y'])
+        assert np.all(self.testInst['sc_zhat_ecef_z']
+                      == -self.testInst['position_ecef_z'])
+
+        # Yhat vector should be orthogonal
+        assert np.all(self.testInst['sc_yhat_ecef_x']
+                      == [0.0, 0.0, 1.0, 0.0, 0.0, -1.0])
+        assert np.all(self.testInst['sc_yhat_ecef_y']
+                      == [0.0, -1.0, 0.0, 0.0, 1.0, 0.0])
+        assert np.all(self.testInst['sc_yhat_ecef_z']
+                      == [1.0, 0.0, 0.0, -1.0, 0.0, 0.0])
         return
 
     def test_project_ecef_vector_onto_sc(self):
         """Test `project_ecef_vector_onto_sc` helper function."""
 
-        # TODO(#64): check if calculations are correct
-        self.testInst.custom_attach(mm_sc.calculate_ecef_velocity)
+        self.testInst.custom_attach(add_ecef_vel)
         self.testInst.custom_attach(mm_sc.add_ram_pointing_sc_attitude_vectors)
         self.testInst.custom_attach(add_fake_data)
         self.testInst.custom_attach(mm_sc.project_ecef_vector_onto_sc,
                                     args=['ax', 'ay', 'az', 'bx', 'by', 'bz'])
         self.testInst.load(date=self.reftime)
-        targets = ['bx', 'by', 'bz']
-        self.eval_targets(targets)
+
+        assert np.all(self.testInst['bx'] == [1.0, 1.0, 0.0, 0.0, 0.0, 0.0])
+        assert np.all(self.testInst['by'] == [0.0, 0.0, 1.0, 0.0, 0.0, -1.0])
+        assert np.all(self.testInst['bz'] == [0.0, 0.0, 0.0, -1.0, -1.0, 0.0])
         return

--- a/pysatMissions/tests/test_methods_spacecraft.py
+++ b/pysatMissions/tests/test_methods_spacecraft.py
@@ -3,6 +3,7 @@
 
 import datetime as dt
 import numpy as np
+import warnings
 
 import pysat
 from pysatMissions.methods import spacecraft as mm_sc
@@ -76,6 +77,18 @@ class TestBasics(object):
         self.testInst.load(date=self.reftime)
         targets = ['velocity_ecef_x', 'velocity_ecef_y', 'velocity_ecef_z']
         self.eval_targets(targets)
+        return
+
+    def test_calculate_ecef_velocity_deprecation(self):
+        """Test `calculate_ecef_velocity` helper function."""
+
+        self.testInst.custom_attach(mm_sc.calculate_ecef_velocity)
+        warnings.simplefilter("always", DeprecationWarning)
+        with warnings.catch_warnings(record=True) as war:
+            self.testInst.load(date=self.reftime)
+        warn_msgs = ["`calculate_ecef_velocity` has been deprecated"]
+
+        pysat.utils.testing.eval_warnings(war, warn_msgs)
         return
 
     def test_add_ram_pointing_sc_attitude_vectors(self):


### PR DESCRIPTION
# Description

Addresses #64

Adds checks on the vector projection calculations in the unit tests.

Deprecates the `calculate_ecef_velocity` function, which is only used by the deprecated `missions_ephem` module.  Calculations from either geospacepy or skyfield can be used instead.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

unit tests and check cross products of unit vectors.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
