### PR TITLE
MAINT: GA standards and Doc bugs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,9 +49,9 @@ jobs:
       if: ${{ matrix.numpy_ver == 'latest'}}
       run: |
         pip install -r requirements.txt
-        pip install aacgmv2 --no-cache-dir
-        pip install apexpy --no-cache-dir
-        pip install OMMBV --no-cache-dir
+        pip install aacgmv2 --no-binary==aacgmv2
+        pip install apexpy --no-binary==apexpy
+        pip install OMMBV --no-binary==OMMBV
 
     - name: Set up pysat
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,9 +49,9 @@ jobs:
       if: ${{ matrix.numpy_ver == 'latest'}}
       run: |
         pip install -r requirements.txt
-        pip install aacgmv2 --no-binary==aacgmv2
-        pip install apexpy --no-binary==apexpy
-        pip install OMMBV --no-binary==OMMBV
+        pip install aacgmv2 --no-cache-dir
+        pip install apexpy --no-cache-dir
+        pip install OMMBV --no-cache-dir
 
     - name: Set up pysat
       run: |

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -4,7 +4,7 @@
 
 name: Test install of latest RC from pip
 
-on: [push]
+on: [workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -28,3 +28,12 @@ jobs:
 
     - name: Install pysatMissions RC
       run: pip install --no-deps --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pysatMissions
+
+    - name: Set up pysat
+      run: |
+        mkdir pysatData
+        python -c "import pysat; pysat.params['data_dirs'] = 'pysatData'"
+    - name: Check that install imports correctly
+      run: |
+        cd ..
+        python -c "import pysatMissions; print(pysatMissions.__version__)"

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -1,0 +1,30 @@
+# This workflow will install Python dependencies and the latest RC of pysatNASA from test pypi.
+# This test should be manually run before a pysatNASA RC is officially approved and versioned.
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Test install of latest RC from pip
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.10"]  # Keep this version at the highest supported Python version
+
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install standard dependencies
+      run: pip install -r requirements.txt
+
+    - name: Install pysatMissions RC
+      run: pip install --no-deps --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pysatMissions

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -3,7 +3,7 @@
 
 name: Test with latest pysat RC
 
-on: [push]
+on: [workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install pysat RC
-      run: pip install --no-deps -i https://test.pypi.org/simple/ pysat
+      run: pip install --no-deps --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pysat
 
     - name: Install standard dependencies
       run: |

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -3,7 +3,7 @@
 
 name: Test with latest pysat RC
 
-on: [workflow_dispatch]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
         python-version: ["3.10"]
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.X.X] - 2022-XX-XX
+## [0.X.X] - 2023-XX-XX
 * Maintenance
   * Update pytest syntax
   * Update Github Actions versions
   * Add manual GitHub Actions tests for pysat RC
   * Add manual GitHub Actions tests for optional dependencies
+  * Add manual GitHub Actions tests for pysatMissions RC
   * Remove optional dependencies in readthedocs requirements
   * Add tests for NEP 29 testing
   * Add tests for Mac OS

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -15,7 +15,7 @@ accessing the Altitude-Adjusted Corrected Geomagnetic (AACGM) coordinates.
   9139–9143.
 * Shepherd, S. G. (2014). Altitude−adjusted corrected geomagnetic coordinates:
   Definition and functional approximations. Journal of Geophysical Research:
-  Space Physics, 119, 7501–7521. https://doi.org/10.1002/2014JA020264
+  Space Physics, 119, 7501–7521. DOI: 10.1002/2014JA020264
 
 apexpy
 ------
@@ -31,7 +31,7 @@ calculating magnetic apex coordinates.
 * Emmert, J. T., Richmond, A. D., & Drob, D. P. (2010). A computationally
   compact representation of magnetic-apex and quasi-dipole coordinates with
   smooth base vectors. Journal of Geophysical Research, 115, A08322.
-  https://doi.org/10.1029/2010JA015326
+  DOI: 10.1029/2010JA015326
 * Laundal, K. M., & Richmond, A. D. (2017). Magnetic coordinate systems. Space
   Science Reviews, 206, 27–59
 


### PR DESCRIPTION
# Description

Updates several bugs in the RC testing due to new behaviour at Github Actions.
- `--no_binary` is removed in latest pip
- Use `--pre` for pip to include pre-release versions at test pypi
- Use `--extra-index-url` to support wheel builds

Also fixes "broken" links (wiley is blocking the redirect, so doi is used without a link)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

via github actions

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
