### PR TITLE
MAINT: NEP29 for Apr 2024, GitHub Actions updates

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,9 +16,9 @@ jobs:
 
     name: Documentation tests
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/external_rc.yml
+++ b/.github/workflows/external_rc.yml
@@ -24,9 +24,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install standard dependencies
-      run: |
-        pip install -r requirements.txt
-        pip install -r test_requirements.txt
+      run: pip install .[test]
 
     - name: Install RC dependency
       run: pip install -i https://test.pypi.org/simple/  --extra-index-url https://pypi.org/simple/ ${{ matrix.rc-package }}

--- a/.github/workflows/external_rc.yml
+++ b/.github/workflows/external_rc.yml
@@ -11,15 +11,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10"]
+        python-version: ["3.12"]
         rc-package: ["aacgmv2", "apexpy", "OMMBV"]
 
     name: ${{ matrix.rc-package }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,19 +12,19 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11", "3.12"]
         numpy_ver: ["latest"]
         include:
-          - python-version: "3.9"
-            numpy_ver: "1.22"
+          - python-version: "3.10"
+            numpy_ver: "1.23"
             os: "ubuntu-latest"
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.11"]  # Keep this version at the highest supported Python version
+        python-version: ["3.12"]  # Keep this version at the highest supported Python version
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -10,23 +10,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
-        python-version: ["3.10"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.11", "3.12"]
+        numpy_ver: ["latest"]
+        include:
+          - python-version: "3.10"
+            numpy_ver: "1.23"
+            os: "ubuntu-latest"
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Install NEP29 dependencies
+      if: ${{ matrix.numpy_ver != 'latest'}}
+      run: pip install numpy==${{ matrix.numpy_ver }}
 
     - name: Install pysat RC
       run: pip install --no-deps --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pysat
 
     - name: Install standard dependencies
-      run: pip install .[test]
+      run: pip install --upgrade-strategy only-if-needed .[test]
 
     - name: Set up pysat
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.3.X] - XXXX-XX-XX
+## [0.3.5] - 2024-XX-XX
 * Maintenance
   * Update workflows coveralls usage
   * Update NEP29
   * Update headers and add acknowledgements
+  * Update GitHub Actions workflows for NEP29 (Apr 2024)
 
 ## [0.3.4] - 2023-06-22
 * Add support for skyfield propagation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysatMissions"
-version = "0.3.4"
+version = "0.3.5"
 description = "Mission Planning toolkit for pysat"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 authors = [
     {name = "Jeff Klenzing", email = "pysat.developers@gmail.com"}
@@ -21,9 +21,9 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Operating System :: POSIX :: Linux",
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: Microsoft :: Windows"


### PR DESCRIPTION
# Description

- Updates NEP29 for April 2024
- Updates GitHub Actions workflows to use latest versions of python, etc

Note that historically, we have not included the operational environment tests here. 🧟 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via GitHub Actions, including manual jobs here:
[with pysat RC](https://github.com/pysat/pysatMissions/actions/runs/8896797504)
[with optional RCs](https://github.com/pysat/pysatMissions/actions/runs/8896920415) - known bugs for apexpy, OMMBV installs (usage of OMMBV is deprecated)
[pip RC install](https://github.com/pysat/pysatMissions/actions/runs/8896792638)
 
## Test Configuration
* Operating system: Windows, linux, mac
* Version number: Python 3.10, 3.11, 3.12
* numpy 1.23, latest

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
