### PR TITLE
MAINT: Meta header for propagators

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         numpy_ver: ["latest"]
         include:
           - python-version: "3.10"
-            numpy_ver: "1.23"
+            numpy_ver: "1.24"
             os: "ubuntu-latest"
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.python-version
 env/
 build/
 develop-eggs/

--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+pysat_dev

--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,0 @@
-pysat_dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.6] - 2024-XX-XX
+* Maintenance
+  * Update meta headers to include orbital info used in propagation
+
 ## [0.3.5] - 2024-07-16
 * Maintenance
   * Update workflows coveralls usage

--- a/pysatMissions/instruments/missions_sgp4.py
+++ b/pysatMissions/instruments/missions_sgp4.py
@@ -205,10 +205,17 @@ def load(fnames, tag=None, inst_id=None, tle1=None, tle2=None,
                            eccentricity, np.radians(arg_periapsis),
                            np.radians(inclination), np.radians(mean_anomaly),
                            mean_motion, np.radians(raan))
+        # Set header level metadata
+        header = {'alt_periapsis': alt_periapsis, 'alt_apoapsis': alt_apoapsis,
+                  'arg_periapsis': arg_periapsis, 'bstar': bstar,
+                  'inclination': inclination, 'mean_anomaly': mean_anomaly,
+                  'raan': raan}
     else:
         # Otherwise, use TLEs
         satellite = sapi.Satrec.twoline2rv(line1, line2, sapi.WGS72)
         mean_motion = satellite.mm
+        # Set header level metadata
+        header = {'tle1': line1, 'tle2': line2}
 
     if one_orbit:
         ind = times <= (2 * np.pi / mean_motion * 60)
@@ -261,7 +268,7 @@ def load(fnames, tag=None, inst_id=None, tle1=None, tle2=None,
     data.index.name = 'Epoch'
 
     # Create metadata corresponding to variables in load routine
-    meta = pysat.Meta()
+    meta = pysat.Meta(header_data=header)
     meta['Epoch'] = {
         meta.labels.units: 'Milliseconds since 1970-1-1',
         meta.labels.notes: 'UTC time at middle of geophysical measurement.',

--- a/pysatMissions/instruments/missions_skyfield.py
+++ b/pysatMissions/instruments/missions_skyfield.py
@@ -203,10 +203,17 @@ def load(fnames, tag=None, inst_id=None, tle1=None, tle2=None,
                         eccentricity, np.radians(arg_periapsis),
                         np.radians(inclination), np.radians(mean_anomaly),
                         mean_motion, np.radians(raan))
+        # Set header level metadata
+        header = {'alt_periapsis': alt_periapsis, 'alt_apoapsis': alt_apoapsis,
+                  'arg_periapsis': arg_periapsis, 'bstar': bstar,
+                  'inclination': inclination, 'mean_anomaly': mean_anomaly,
+                  'raan': raan}
     else:
         # Otherwise, use TLEs
         satrec = sapi.Satrec.twoline2rv(line1, line2, sapi.WGS84)
         mean_motion = satrec.mm
+        # Set header level metadata
+        header = {'tle1': line1, 'tle2': line2}
 
     if one_orbit:
         ind = times <= (2 * np.pi / mean_motion * 60)
@@ -250,7 +257,7 @@ def load(fnames, tag=None, inst_id=None, tle1=None, tle2=None,
     data.index.name = 'Epoch'
 
     # Create metadata corresponding to variables in load routine
-    meta = pysat.Meta()
+    meta = pysat.Meta(header_data=header)
     meta['Epoch'] = {
         meta.labels.units: 'Milliseconds since 1970-1-1',
         meta.labels.notes: 'UTC time at middle of geophysical measurement.',

--- a/pysatMissions/instruments/missions_skyfield.py
+++ b/pysatMissions/instruments/missions_skyfield.py
@@ -203,6 +203,7 @@ def load(fnames, tag=None, inst_id=None, tle1=None, tle2=None,
                         eccentricity, np.radians(arg_periapsis),
                         np.radians(inclination), np.radians(mean_anomaly),
                         mean_motion, np.radians(raan))
+
         # Set header level metadata
         header = {'alt_periapsis': alt_periapsis, 'alt_apoapsis': alt_apoapsis,
                   'arg_periapsis': arg_periapsis, 'bstar': bstar,
@@ -212,6 +213,7 @@ def load(fnames, tag=None, inst_id=None, tle1=None, tle2=None,
         # Otherwise, use TLEs
         satrec = sapi.Satrec.twoline2rv(line1, line2, sapi.WGS84)
         mean_motion = satrec.mm
+
         # Set header level metadata
         header = {'tle1': line1, 'tle2': line2}
 


### PR DESCRIPTION
# Description

Adds orbital info used for propagation to global metadata values. If Keplerian elements are used in generation, then only those elements (including default values) are added. If TLEs are used, only those default values are used.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Loading an instrument and inspecting for header data.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
