### PR TITLE
BUG/TST: Fix external RC tests, add mac testing, bump NEP29 numpy

### DIFF
--- a/.github/workflows/external_rc.yml
+++ b/.github/workflows/external_rc.yml
@@ -27,7 +27,7 @@ jobs:
       run: pip install .[test]
 
     - name: Install RC dependency
-      run: pip install -pre -i https://test.pypi.org/simple/  --extra-index-url https://pypi.org/simple/ ${{ matrix.rc-package }}
+      run: pip install --pre -i https://test.pypi.org/simple/  --extra-index-url https://pypi.org/simple/ ${{ matrix.rc-package }}
 
     - name: Set up pysat
       run: |

--- a/.github/workflows/external_rc.yml
+++ b/.github/workflows/external_rc.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.12"]
         rc-package: ["aacgmv2", "apexpy", "OMMBV"]
 

--- a/.github/workflows/external_rc.yml
+++ b/.github/workflows/external_rc.yml
@@ -27,7 +27,7 @@ jobs:
       run: pip install .[test]
 
     - name: Install RC dependency
-      run: pip install -i https://test.pypi.org/simple/  --extra-index-url https://pypi.org/simple/ ${{ matrix.rc-package }}
+      run: pip install -pre -i https://test.pypi.org/simple/  --extra-index-url https://pypi.org/simple/ ${{ matrix.rc-package }}
 
     - name: Set up pysat
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         numpy_ver: ["latest"]
         include:
           - python-version: "3.10"
-            numpy_ver: "1.24"
+            numpy_ver: "1.25"
             os: "ubuntu-latest"
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -15,7 +15,7 @@ jobs:
         numpy_ver: ["latest"]
         include:
           - python-version: "3.10"
-            numpy_ver: "1.23"
+            numpy_ver: "1.25"
             os: "ubuntu-latest"
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.3.6] - 2024-XX-XX
 * Maintenance
   * Update meta headers to include orbital info used in propagation
+  * Update external RC tests to include Mac environment testing
+  * Update NEP29 minimum to numpy 1.25
 
 ## [0.3.5] - 2024-07-16
 * Maintenance


### PR DESCRIPTION
# Description

Updates tests for external optional installs, partially in support of https://github.com/aburrell/aacgmv2/pull/93. 
- Fixes a bug where the pre-release candidates are not downloaded
- Adds support for mac tests for the external RC workflow
- Bumps minimum numpy to 1.25 for NEP29 tests

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

via manual workflow initiated [here](https://github.com/pysat/pysatMissions/actions/runs/12550732374) and verifying that
- aacgmv2 2.7.0rc1 is installed
- the optional test `test_methods_magcoord.py::TestBasics::test_add_coordinates[add_aacgm_coordinates-targets0]` is run and passed

## Test Configuration
* Operating system: Mac, ubuntu, windows
* Version number: Python 3.12

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
